### PR TITLE
찜하기 기능 구현 + 로딩 상태

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,10 +50,24 @@ function App() {
     }, [loggedInUserId]);
 
     const handleLogout = () => {
-        pb.authStore.clear(); // PocketBase 인증 상태 초기화
-        setIsLoggedIn(false); // 로그인 상태 초기화
-        setLoggedInUserId(null); // 사용자 ID 초기화
-        localStorage.clear(); // 모든 localStorage 데이터 초기화
+        // PocketBase 인증 상태 초기화
+        pb.authStore.clear(); 
+    
+        // 유지하려는 데이터를 저장
+        const favoritesKey = `favorites_${loggedInUserId}`;
+        const savedFavorites = localStorage.getItem(favoritesKey);
+    
+        // localStorage 초기화
+        localStorage.clear(); 
+    
+        // 저장한 데이터를 다시 설정
+        if (savedFavorites) {
+            localStorage.setItem(favoritesKey, savedFavorites);
+        }
+    
+        // 상태 초기화
+        setIsLoggedIn(false);
+        setLoggedInUserId(null);
     };
 
     return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,25 +49,29 @@ function App() {
         localStorage.setItem("loggedInUserId", loggedInUserId);
     }, [loggedInUserId]);
 
+
     const handleLogout = () => {
         // PocketBase 인증 상태 초기화
         pb.authStore.clear(); 
     
-        // 유지하려는 데이터를 저장
+        // 유지하려는 데이터를 저장 (찜 목록)
         const favoritesKey = `favorites_${loggedInUserId}`;
         const savedFavorites = localStorage.getItem(favoritesKey);
     
-        // localStorage 초기화
-        localStorage.clear(); 
+        // localStorage에서 특정 항목들만 초기화
+        localStorage.removeItem('loggedInUserId');
+        localStorage.removeItem('isdarkMode');
+        localStorage.removeItem('pocketbase_auth');
     
-        // 저장한 데이터를 다시 설정
-        if (savedFavorites) {
-            localStorage.setItem(favoritesKey, savedFavorites);
-        }
-    
-        // 상태 초기화
+        // 로그인 상태 초기화
         setIsLoggedIn(false);
         setLoggedInUserId(null);
+    
+        // 찜 목록 데이터가 있다면, 다시 로그인할 때 저장할 수 있도록 설정
+        if (savedFavorites) {
+            // 로그인할 때 해당 키로 찜 목록을 다시 저장
+            localStorage.setItem(favoritesKey, savedFavorites); // key와 value를 정확히 지정
+        }
     };
 
     return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import pb from "./lib/pocketbase";
 import Register from "./Auth/Register";
 import Login from "./Auth/Login";
 import RegistrationSuccess from "./Auth/RegistrationSuccess";
@@ -16,11 +17,18 @@ function App() {
         const savedMode = localStorage.getItem("isdarkMode");
         return savedMode === "true"; // 'true'로 저장된 값이면 true, 아니면 false
     });
-
+    
     const [isLoggedIn, setIsLoggedIn] = useState(() => {
         const storedLoginStatus = localStorage.getItem("isLoggedIn");
         return storedLoginStatus === "true"; // 'true'로 저장된 값이면 true, 아니면 false
     });
+
+    // 로그인 사용자 저장
+    const [loggedInUserId, setLoggedInUserId] = useState(() => {
+        return localStorage.getItem("loggedInUserId") || null;
+    });
+
+    console.log(loggedInUserId)
 
     // 다크모드 상태가 변경될 때마다 HTML의 <html> 태그에 dark 클래스를 추가하거나 제거
     useEffect(() => {
@@ -37,28 +45,54 @@ function App() {
         localStorage.setItem("isLoggedIn", isLoggedIn); // 변경된 로그인 상태를 localStorage에 저장
     }, [isLoggedIn]);
 
+    useEffect(() => {
+        localStorage.setItem("loggedInUserId", loggedInUserId);
+    }, [loggedInUserId]);
+
+    const handleLogout = () => {
+        pb.authStore.clear(); // PocketBase 인증 상태 초기화
+        setIsLoggedIn(false); // 로그인 상태 초기화
+        setLoggedInUserId(null); // 사용자 ID 초기화
+        localStorage.clear(); // 모든 localStorage 데이터 초기화
+    };
+
     return (
         <Router>
             <Header 
                 isLoggedIn={isLoggedIn} 
                 isdarkMode={isdarkMode} 
-                setDarkMode={setDarkMode} 
+                setDarkMode={setDarkMode}
             />
             <Routes>
                 <Route path="/06-react-vite-pocketbase/" element={<Layout />}>
                     <Route
                         index
-                        element={<Home isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
+                        element={<Home 
+                            isLoggedIn={isLoggedIn} 
+                            setIsLoggedIn={setIsLoggedIn} 
+                            setLoggedInUserId={setLoggedInUserId} 
+                            onLogout={handleLogout} // 로그아웃 함수 전달
+                        />}
                     />
                     <Route
                         path="/06-react-vite-pocketbase/login"
-                        element={<Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
+                        element={<Login 
+                            isLoggedIn={isLoggedIn} 
+                            setIsLoggedIn={setIsLoggedIn} 
+                            setLoggedInUserId={setLoggedInUserId} 
+                        />}
                     />
                     <Route path="/06-react-vite-pocketbase/register" element={<Register />} />
                     <Route path="/06-react-vite-pocketbase/registration-success" element={<RegistrationSuccess />} />
-                    <Route path="/06-react-vite-pocketbase/fileList" element={<FileList />} />
+                    <Route 
+                        path="/06-react-vite-pocketbase/fileList" 
+                        element={<FileList loggedInUserId={loggedInUserId} />} 
+                    />
                     {/* <Route path="/06-react-vite-pocketbase/file/:id" element={<FileDetail />} /> */}
-                    <Route path="/06-react-vite-pocketbase/favorites" element={<FavoriteFiles />} />
+                    <Route 
+                        path="/06-react-vite-pocketbase/favorites" 
+                        element={<FavoriteFiles loggedInUserId={loggedInUserId} />} 
+                    />
                 </Route>
             </Routes>
         </Router>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import FileList from "./components/FileList";
 import FavoriteFiles from "./components/FavoriteFiles";
 
 function App() {
+    const [isLoading, setIsLoading] = useState(false); // 로딩 상태 관리
+
     const [isdarkMode, setDarkMode] = useState(() => {
         const savedMode = localStorage.getItem("isdarkMode");
         return savedMode === "true";
@@ -26,7 +28,7 @@ function App() {
         return localStorage.getItem("loggedInUserId") || null;
     });
 
-    console.log(loggedInUserId)
+    console.log(isLoading)
 
     // 다크모드 상태가 변경될 때마다 HTML의 <html> 태그에 dark 클래스를 추가하거나 제거
     useEffect(() => {
@@ -77,6 +79,8 @@ function App() {
                 isLoggedIn={isLoggedIn} 
                 isdarkMode={isdarkMode} 
                 setDarkMode={setDarkMode}
+                isLoading={isLoading}
+                setIsLoading={setIsLoading}
             />
             <Routes>
                 <Route path="/" element={<Layout />}>
@@ -92,17 +96,19 @@ function App() {
                     <Route path="/login" element={<Login 
                             isLoggedIn={isLoggedIn} 
                             setIsLoggedIn={setIsLoggedIn} 
-                            setLoggedInUserId={setLoggedInUserId} 
+                            setLoggedInUserId={setLoggedInUserId}
+                            isLoading={isLoading}
+                            setIsLoading={setIsLoading}
                         />} />
-                    <Route path="/register" element={<Register />} />
-                    <Route path="/registration-success" element={<RegistrationSuccess />} />
+                    <Route path="/register" element={<Register isLoading={isLoading} setIsLoading={setIsLoading}/>} />
+                    <Route path="/registration-success" element={<RegistrationSuccess isLoading={isLoading} setIsLoading={setIsLoading}/>} />
                     <Route 
                         path="/fileList" 
-                        element={<FileList loggedInUserId={loggedInUserId} />} 
+                        element={<FileList isLoggedIn={isLoggedIn}  loggedInUserId={loggedInUserId} isLoading={isLoading} setIsLoading={setIsLoading}/>} 
                     />
                     <Route 
                         path="/favorites" 
-                        element={<FavoriteFiles loggedInUserId={loggedInUserId} />} 
+                        element={<FavoriteFiles isLoggedIn={isLoggedIn}  loggedInUserId={loggedInUserId} isLoading={isLoading} setIsLoading={setIsLoading}/>} 
                     />
                 </Route>
             </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import Header from "./components/Header";
 import Layout from "./components/Layout"; // Layout 컴포넌트 추가
 import Home from "./components/Home"; // Home 컴포넌트 추가
 import FileList from "./components/FileList";
+// import FileDetail from "./components/FileDetail";
+import FavoriteFiles from "./components/FavoriteFiles";
 
 function App() {
     // 다크모드 상태를 초기화할 때 localStorage에서 값 불러오기
@@ -55,6 +57,8 @@ function App() {
                     <Route path="/06-react-vite-pocketbase/register" element={<Register />} />
                     <Route path="/06-react-vite-pocketbase/registration-success" element={<RegistrationSuccess />} />
                     <Route path="/06-react-vite-pocketbase/fileList" element={<FileList />} />
+                    {/* <Route path="/06-react-vite-pocketbase/file/:id" element={<FileDetail />} /> */}
+                    <Route path="/06-react-vite-pocketbase/favorites" element={<FavoriteFiles />} />
                 </Route>
             </Routes>
         </Router>

--- a/src/Auth/Login.jsx
+++ b/src/Auth/Login.jsx
@@ -3,9 +3,8 @@ import pb from "../lib/pocketbase";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-function Login({ setIsLoggedIn, setLoggedInUserId }) {
+function Login({ setIsLoggedIn, setLoggedInUserId, isLoading, setIsLoading }) {
     const { register, handleSubmit, formState: { errors } } = useForm();
-    const [isLoading, setLoading] = useState(false);
     const [apiError, setApiError] = useState(""); // API 에러 메시지 상태 추가
     const navigate = useNavigate();
 
@@ -16,7 +15,7 @@ function Login({ setIsLoggedIn, setLoggedInUserId }) {
     }, [isLoggedInStatus, navigate]);
 
     async function login(data) {
-        setLoading(true);
+        setIsLoading(true);
         setApiError(""); // 에러 초기화
         try {
             // PocketBase 로그인 요청
@@ -38,7 +37,7 @@ function Login({ setIsLoggedIn, setLoggedInUserId }) {
             // 로그인 실패 시 에러 메시지 설정
             setApiError("Invalid credentials or error occurred.");
         } finally {
-            setLoading(false); // 로딩 상태 해제
+            setIsLoading(false); // 로딩 상태 해제
         }
     }
 
@@ -60,7 +59,10 @@ function Login({ setIsLoggedIn, setLoggedInUserId }) {
                         className="border rounded-md p-1"
                         type="email"
                         placeholder="Input your email"
-                        {...register("email", { required: "Email is required" })}
+                        {...register("email", { 
+                            required: "Email is required" }
+                        )}
+                        disabled={isLoading} // 로딩 중 비활성화
                     />
                     <p className="text-red-500">{errors.email?.message}</p>
 
@@ -72,6 +74,7 @@ function Login({ setIsLoggedIn, setLoggedInUserId }) {
                             required: "Password is required",
                             minLength: { value: 6, message: "Password must be at least 6 characters" }
                         })}
+                        disabled={isLoading} // 로딩 중 비활성화
                     />
                     <p className="text-red-500">{errors.password?.message}</p>
 

--- a/src/components/FavoriteFiles.jsx
+++ b/src/components/FavoriteFiles.jsx
@@ -3,7 +3,7 @@ import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
 import FileListSkeleton from "./FileListSkeleton";
 
-const FavoriteFiles = () => {
+const FavoriteFiles = ({ loggedInUserId }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [favorites, setFavorites] = useState(() => {
         const storedFavorites = localStorage.getItem("favorites");
@@ -12,27 +12,18 @@ const FavoriteFiles = () => {
     const [favoriteFiles, setFavoriteFiles] = useState([]);
 
     useEffect(() => {
-        const fetchFavoriteFiles = async () => {
-            try {
-                const fileIds = Object.keys(favorites).filter((id) => favorites[id]);
-                const files = await Promise.all(
-                    fileIds.map((id) => pb.collection("files").getOne(id))
-                );
-                setFavoriteFiles(files.map(file => ({
-                    id: file.id,
-                    imageUrl: getPbImageURL(file, "photo"),
-                    name: file.name || "No name",
-                    price: file.price || 0,
-                })));
-            } catch (error) {
-                console.error("Error fetching favorite files:", error);
-            } finally {
-                setIsLoading(false);
-            }
-        };
+        // if (!loggedInUserId) return;
 
-        fetchFavoriteFiles();
-    }, [favorites]);
+        const storedFiles = localStorage.getItem("fileData");
+        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
+        if (storedFiles && storedFavorites) {
+            const parsedFiles = JSON.parse(storedFiles);
+            const parsedFavorites = JSON.parse(storedFavorites);
+            const filteredFiles = parsedFiles.filter((file) => parsedFavorites[file.id]);
+            setFavoriteFiles(filteredFiles);
+        }
+        
+    }, [loggedInUserId]);
 
     const handleRemoveFavorite = (id) => {
         setFavorites((prev) => {

--- a/src/components/FavoriteFiles.jsx
+++ b/src/components/FavoriteFiles.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import FileListSkeleton from "./FileListSkeleton";
+import pb from "../lib/pocketbase";
+import getPbImageURL from "../lib/getPbImageURL";
 
 const FavoriteFiles = ({ loggedInUserId }) => {
     const [isLoading, setIsLoading] = useState(true);
@@ -8,38 +10,55 @@ const FavoriteFiles = ({ loggedInUserId }) => {
     useEffect(() => {
         if (!loggedInUserId) return; // loggedInUserId가 없으면 실행하지 않음
     
-        const storedFiles = localStorage.getItem("fileData"); // 파일 데이터 로드
-        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`); // 찜 데이터 로드
-    
-        if (storedFiles && storedFavorites) {
-            const parsedFiles = JSON.parse(storedFiles);
+        // 로컬 스토리지에서 찜 목록을 가져옴
+        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
+
+        if (storedFavorites) {
             const parsedFavorites = JSON.parse(storedFavorites);
-    
-            const filteredFiles = parsedFiles.filter((file) => parsedFavorites[file.id]);
-            setFavoriteFiles(filteredFiles); // 찜한 파일만 설정
+
+            // 파일 데이터를 API에서 가져옴 (PocketBase)
+            pb.collection("files")
+                .getFullList(1, { autoCancel: false })
+                .then((files) => {
+                    const formattedFiles = files.map((file) => ({
+                        id: file.id,
+                        imageUrl: getPbImageURL(file, "photo"), // 정확한 이미지 URL을 사용해야 함
+                        name: file.name || "No name",
+                        price: file.price || 0,
+                    }));
+
+                    // 찜 목록에 해당하는 파일만 필터링
+                    const filteredFiles = formattedFiles.filter((file) => parsedFavorites[file.id]);
+                    setFavoriteFiles(filteredFiles); // 찜한 파일만 설정
+                })
+                .catch((error) => console.error("파일을 가져오는 중 오류 발생:", error))
+                .finally(() => setIsLoading(false)); // 파일을 가져온 후 로딩 상태 해제
+        } else {
+            setIsLoading(false); // 찜 목록이 없으면 로딩 상태 해제
         }
-        setIsLoading(false); // 로딩 상태 해제
-    }, [loggedInUserId]);
+    }, [loggedInUserId]); // loggedInUserId가 변경될 때마다 실행
 
     const handleRemoveFavorite = (id) => {
         const favoritesKey = `favorites_${loggedInUserId}`;
         const storedFavorites = JSON.parse(localStorage.getItem(favoritesKey)) || {};
-        
+
+        // 찜 목록에서 해당 파일의 상태를 변경
         const updatedFavorites = { ...storedFavorites, [id]: false };
         localStorage.setItem(favoritesKey, JSON.stringify(updatedFavorites));
 
+        // 화면에서 찜한 파일 목록에서 제거
         setFavoriteFiles((prevFiles) => prevFiles.filter((file) => file.id !== id));
     };
 
     if (isLoading) {
-        return <FileListSkeleton />; // Show skeleton UI while loading
+        return <FileListSkeleton />; // 로딩 중일 때 스켈레톤 UI 표시
     }
 
-    if (!favoriteFiles.length) return <p>No favorite files.</p>;
+    if (!favoriteFiles.length) return <p>찜한 파일이 없습니다.</p>;
 
     return (
         <>
-            <h2 className="sr-only">제품 리스트</h2>
+            <h2 className="sr-only">찜한 제품 리스트</h2>
             <ul className="grid grid-cols-2 gap-2 md:gap-4 md:mb-6 md:grid-cols-4 lg:gap-6 lg:col-start-2 lg:row-end-6 lg:row-span-6 lg:mb-0">
                 {favoriteFiles.map((file) => (
                     <li key={file.id} className="cursor-pointer overflow-hidden">

--- a/src/components/FavoriteFiles.jsx
+++ b/src/components/FavoriteFiles.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from "react";
+import pb from "../lib/pocketbase";
+import getPbImageURL from "../lib/getPbImageURL";
+
+
+const FavoriteFiles = () => {
+    const [favorites, setFavorites] = useState(() => {
+        const storedFavorites = localStorage.getItem("favorites");
+        return storedFavorites ? JSON.parse(storedFavorites) : {};
+    });
+    const [favoriteFiles, setFavoriteFiles] = useState([]);
+
+    useEffect(() => {
+        const fetchFavoriteFiles = async () => {
+            try {
+                const fileIds = Object.keys(favorites).filter((id) => favorites[id]);
+                const files = await Promise.all(
+                    fileIds.map((id) => pb.collection("files").getOne(id))
+                );
+                setFavoriteFiles(files.map(file => ({
+                    id: file.id,
+                    imageUrl: getPbImageURL(file, "photo"),
+                    name: file.name || "No name",
+                    price: file.price || 0,
+                })));
+            } catch (error) {
+                console.error("Error fetching favorite files:", error);
+            }
+        };
+
+        fetchFavoriteFiles();
+    }, [favorites]);
+
+    if (!favoriteFiles.length) return <p>No favorite files.</p>;
+
+    return (
+        <>
+            <h2 className="sr-only">제품 리스트</h2>
+            <ul className="grid grid-cols-2 gap-2 md:gap-4 md:mb-6 md:grid-cols-4 lg:gap-6 lg:col-start-2 lg:row-end-6 lg:row-span-6 lg:mb-0">
+                {favoriteFiles.map((file, index) => (
+                    <li key={index} className="cursor-pointer overflow-hidden">
+                        <figure className="rounded-xl overflow-hidden mb-2 flex items-center h-[180px] md:h-[240px] lg:h-[320px]">
+                            <img 
+                                src={file.imageUrl} 
+                                alt={file.name} 
+                                loading="lazy"
+                                decoding="async"
+                                width="800px"
+                                height="800px"
+                                className="w-full"
+                                />
+                        </figure>
+                        <div className="flex flex-col">
+                            <span className="text-sm font-bold dark:text-white">{file.name}</span>
+                            <span className="text-sm font-bold text-zinc-600 dark:text-slate-400">{file.price}원</span>
+                        </div>
+                        
+                    </li>
+                ))}
+            </ul>
+        </>
+    );
+};
+
+
+export default FavoriteFiles

--- a/src/components/FavoriteFiles.jsx
+++ b/src/components/FavoriteFiles.jsx
@@ -1,36 +1,34 @@
 import React, { useEffect, useState } from "react";
-import pb from "../lib/pocketbase";
-import getPbImageURL from "../lib/getPbImageURL";
 import FileListSkeleton from "./FileListSkeleton";
 
 const FavoriteFiles = ({ loggedInUserId }) => {
     const [isLoading, setIsLoading] = useState(true);
-    const [favorites, setFavorites] = useState(() => {
-        const storedFavorites = localStorage.getItem("favorites");
-        return storedFavorites ? JSON.parse(storedFavorites) : {};
-    });
     const [favoriteFiles, setFavoriteFiles] = useState([]);
 
     useEffect(() => {
-        // if (!loggedInUserId) return;
-
-        const storedFiles = localStorage.getItem("fileData");
-        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
+        if (!loggedInUserId) return; // loggedInUserId가 없으면 실행하지 않음
+    
+        const storedFiles = localStorage.getItem("fileData"); // 파일 데이터 로드
+        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`); // 찜 데이터 로드
+    
         if (storedFiles && storedFavorites) {
             const parsedFiles = JSON.parse(storedFiles);
             const parsedFavorites = JSON.parse(storedFavorites);
+    
             const filteredFiles = parsedFiles.filter((file) => parsedFavorites[file.id]);
-            setFavoriteFiles(filteredFiles);
+            setFavoriteFiles(filteredFiles); // 찜한 파일만 설정
         }
-        
+        setIsLoading(false); // 로딩 상태 해제
     }, [loggedInUserId]);
 
     const handleRemoveFavorite = (id) => {
-        setFavorites((prev) => {
-            const updatedFavorites = { ...prev, [id]: false };
-            localStorage.setItem("favorites", JSON.stringify(updatedFavorites));
-            return updatedFavorites;
-        });
+        const favoritesKey = `favorites_${loggedInUserId}`;
+        const storedFavorites = JSON.parse(localStorage.getItem(favoritesKey)) || {};
+        
+        const updatedFavorites = { ...storedFavorites, [id]: false };
+        localStorage.setItem(favoritesKey, JSON.stringify(updatedFavorites));
+
+        setFavoriteFiles((prevFiles) => prevFiles.filter((file) => file.id !== id));
     };
 
     if (isLoading) {
@@ -43,8 +41,8 @@ const FavoriteFiles = ({ loggedInUserId }) => {
         <>
             <h2 className="sr-only">제품 리스트</h2>
             <ul className="grid grid-cols-2 gap-2 md:gap-4 md:mb-6 md:grid-cols-4 lg:gap-6 lg:col-start-2 lg:row-end-6 lg:row-span-6 lg:mb-0">
-                {favoriteFiles.map((file, index) => (
-                    <li key={index} className="cursor-pointer overflow-hidden">
+                {favoriteFiles.map((file) => (
+                    <li key={file.id} className="cursor-pointer overflow-hidden">
                         <figure className="rounded-xl overflow-hidden mb-2 flex items-center h-[180px] md:h-[240px] lg:h-[320px]">
                             <img 
                                 src={file.imageUrl} 
@@ -54,7 +52,7 @@ const FavoriteFiles = ({ loggedInUserId }) => {
                                 width="800px"
                                 height="800px"
                                 className="w-full"
-                                />
+                            />
                         </figure>
                         <div className="flex flex-col">
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>
@@ -73,5 +71,4 @@ const FavoriteFiles = ({ loggedInUserId }) => {
     );
 };
 
-
-export default FavoriteFiles
+export default FavoriteFiles;

--- a/src/components/FavoriteFiles.jsx
+++ b/src/components/FavoriteFiles.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
 import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
-
+import FileListSkeleton from "./FileListSkeleton";
 
 const FavoriteFiles = () => {
+    const [isLoading, setIsLoading] = useState(true);
     const [favorites, setFavorites] = useState(() => {
         const storedFavorites = localStorage.getItem("favorites");
         return storedFavorites ? JSON.parse(storedFavorites) : {};
@@ -25,11 +26,25 @@ const FavoriteFiles = () => {
                 })));
             } catch (error) {
                 console.error("Error fetching favorite files:", error);
+            } finally {
+                setIsLoading(false);
             }
         };
 
         fetchFavoriteFiles();
     }, [favorites]);
+
+    const handleRemoveFavorite = (id) => {
+        setFavorites((prev) => {
+            const updatedFavorites = { ...prev, [id]: false };
+            localStorage.setItem("favorites", JSON.stringify(updatedFavorites));
+            return updatedFavorites;
+        });
+    };
+
+    if (isLoading) {
+        return <FileListSkeleton />; // Show skeleton UI while loading
+    }
 
     if (!favoriteFiles.length) return <p>No favorite files.</p>;
 
@@ -54,7 +69,12 @@ const FavoriteFiles = () => {
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>
                             <span className="text-sm font-bold text-zinc-600 dark:text-slate-400">{file.price}원</span>
                         </div>
-                        
+                        <button
+                            onClick={() => handleRemoveFavorite(file.id)}
+                            className="text-sm text-red-500"
+                        >
+                            찜 취소
+                        </button>
                     </li>
                 ))}
             </ul>

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -1,17 +1,37 @@
 import React, { useState, useEffect } from "react";
 import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
-import FileListSkeleton from "./FileListSkeleton"; // import the skeleton component
+import FileListSkeleton from "./FileListSkeleton";
 
-const FileList = () => {
+const FileList = ({ loggedInUserId }) => {
     const [fileData, setFileData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [favorites, setFavorites] = useState(() => {
+        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
+        return storedFavorites ? JSON.parse(storedFavorites) : {};
+    });
+
+    const toggleFavorite = (id) => {
+        // 테스트 완료 후 활성
+        // if (!loggedInUserId) {
+        //     alert("로그인이 필요합니다.");
+        //     return;
+        // }
+
+        setFavorites((prev) => {
+            const updatedFavorites = { ...prev, [id]: !prev[id] };
+            localStorage.setItem(`favorites_${loggedInUserId}`, JSON.stringify(updatedFavorites)); // LocalStorage에 저장
+            
+            return updatedFavorites;
+        });
+    };
 
     useEffect(() => {
         const fetchFiles = async () => {
             try {
                 const files = await pb.collection("files").getFullList(1, { autoCancel: false });
                 setFileData(files.map(file => ({
+                    id: file.id, // file.id 추가
                     imageUrl: getPbImageURL(file, "photo"),
                     name: file.name || "No name",
                     price: file.price || 0,
@@ -55,6 +75,12 @@ const FileList = () => {
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>
                             <span className="text-sm font-bold text-zinc-600 dark:text-slate-400">{file.price}원</span>
                         </div>
+                        <button
+                            onClick={() => toggleFavorite(file.id)} // 찜 상태 변경
+                            className={`text-sm ${favorites[file.id] ? "text-red-500" : "text-gray-500"}`}
+                        >
+                            {favorites[file.id] ? "찜 취소" : "찜하기"}
+                        </button>
                     </li>
                 ))}
             </ul>

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -1,11 +1,25 @@
 import React, { useState, useEffect } from "react";
 import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
-import FileListSkeleton from "./FileListSkeleton"; // import the skeleton component
+import FileListSkeleton from "./FileListSkeleton";
 
 const FileList = () => {
     const [fileData, setFileData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [favorites, setFavorites] = useState(() => {
+        // LocalStorage에서 찜 목록 초기화
+        const storedFavorites = localStorage.getItem("favorites");
+        return storedFavorites ? JSON.parse(storedFavorites) : {};
+    });
+
+    const toggleFavorite = (id) => {
+        setFavorites((prev) => {
+            const updatedFavorites = { ...prev, [id]: !prev[id] };
+            localStorage.setItem("favorites", JSON.stringify(updatedFavorites)); // LocalStorage에 저장
+            console.log(id)
+            return updatedFavorites;
+        });
+    };
 
     useEffect(() => {
         const fetchFiles = async () => {
@@ -55,6 +69,12 @@ const FileList = () => {
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>
                             <span className="text-sm font-bold text-zinc-600 dark:text-slate-400">{file.price}원</span>
                         </div>
+                        <button
+                            onClick={() => toggleFavorite(file.id)} // 찜 상태 변경
+                            className={`text-sm ${favorites[file.id] ? "text-red-500" : "text-gray-500"}`}
+                        >
+                            {favorites[file.id] ? "찜 취소" : "찜하기"}
+                        </button>
                     </li>
                 ))}
             </ul>

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -38,15 +38,17 @@ const FileList = ({ loggedInUserId }) => {
                     price: file.price || 0,
                 }));
                 setFileData(formattedFiles);
+                // 파일 데이터를 로컬 스토리지에 저장
+                localStorage.setItem("fileData", JSON.stringify(formattedFiles));
             } catch (error) {
                 console.error("Error fetching files:", error);
             } finally {
                 setIsLoading(false);
             }
         };
-
+    
         fetchFiles();
-    }, []);
+    }, []);    
 
     if (isLoading) {
         return <FileListSkeleton />; // Show skeleton UI while loading

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -26,6 +26,7 @@ const FileList = () => {
             try {
                 const files = await pb.collection("files").getFullList(1, { autoCancel: false });
                 setFileData(files.map(file => ({
+                    id: file.id, // file.id 추가
                     imageUrl: getPbImageURL(file, "photo"),
                     name: file.name || "No name",
                     price: file.price || 0,

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -1,54 +1,30 @@
 import React, { useState, useEffect } from "react";
 import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
-import FileListSkeleton from "./FileListSkeleton";
+import FileListSkeleton from "./FileListSkeleton"; // import the skeleton component
 
-const FileList = ({ loggedInUserId }) => {
+const FileList = () => {
     const [fileData, setFileData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [favorites, setFavorites] = useState(() => {
-        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
-        return storedFavorites ? JSON.parse(storedFavorites) : {};
-    });
-
-    const toggleFavorite = (id) => {
-        // 테스트 완료 후 활성
-        // if (!loggedInUserId) {
-        //     alert("로그인이 필요합니다.");
-        //     return;
-        // }
-
-        setFavorites((prev) => {
-            const updatedFavorites = { ...prev, [id]: !prev[id] };
-            localStorage.setItem(`favorites_${loggedInUserId}`, JSON.stringify(updatedFavorites)); // LocalStorage에 저장
-            console.log(id)
-            console.log(loggedInUserId)
-            return updatedFavorites;
-        });
-    };
 
     useEffect(() => {
         const fetchFiles = async () => {
             try {
                 const files = await pb.collection("files").getFullList(1, { autoCancel: false });
-                const formattedFiles = files.map((file) => ({
-                    id: file.id,
+                setFileData(files.map(file => ({
                     imageUrl: getPbImageURL(file, "photo"),
                     name: file.name || "No name",
                     price: file.price || 0,
-                }));
-                setFileData(formattedFiles);
-                // 파일 데이터를 로컬 스토리지에 저장
-                localStorage.setItem("fileData", JSON.stringify(formattedFiles));
+                })));
             } catch (error) {
                 console.error("Error fetching files:", error);
             } finally {
                 setIsLoading(false);
             }
         };
-    
+
         fetchFiles();
-    }, []);    
+    }, []);
 
     if (isLoading) {
         return <FileListSkeleton />; // Show skeleton UI while loading
@@ -79,12 +55,6 @@ const FileList = ({ loggedInUserId }) => {
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>
                             <span className="text-sm font-bold text-zinc-600 dark:text-slate-400">{file.price}원</span>
                         </div>
-                        <button
-                            onClick={() => toggleFavorite(file.id)} // 찜 상태 변경
-                            className={`text-sm ${favorites[file.id] ? "text-red-500" : "text-gray-500"}`}
-                        >
-                            {favorites[file.id] ? "찜 취소" : "찜하기"}
-                        </button>
                     </li>
                 ))}
             </ul>

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -2,36 +2,43 @@ import React, { useState, useEffect } from "react";
 import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
 import FileListSkeleton from "./FileListSkeleton";
+import { useNavigate } from "react-router-dom";
 
-const FileList = ({ loggedInUserId }) => {
-    const [fileData, setFileData] = useState([]);
-    const [isLoading, setIsLoading] = useState(true);
+const FileList = ({ isLoggedIn, loggedInUserId, isLoading, setIsLoading }) => {
+    const navigate = useNavigate();
+    const [ fileData, setFileData ] = useState([]); // 실제 데이터 상태
+    const [ dataloading, setDataLoading ] = useState(true); // 로딩 상태, 데이터 로딩을 나타내기 위한 상태
     const [favorites, setFavorites] = useState(() => {
         const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
         return storedFavorites ? JSON.parse(storedFavorites) : {};
     });
 
     const toggleFavorite = (id) => {
-        // 테스트 완료 후 활성
-        // if (!loggedInUserId) {
-        //     alert("로그인이 필요합니다.");
-        //     return;
-        // }
+        // 로그인 상태가 아니면 알림을 띄우고 종료
+        if (!isLoggedIn || !loggedInUserId) {
+            alert("로그인이 필요합니다.");
+            navigate("/login");
+            return;
+        }
 
         setFavorites((prev) => {
             const updatedFavorites = { ...prev, [id]: !prev[id] };
             localStorage.setItem(`favorites_${loggedInUserId}`, JSON.stringify(updatedFavorites)); // LocalStorage에 저장
-            
+
             return updatedFavorites;
         });
     };
 
     useEffect(() => {
         const fetchFiles = async () => {
+            setIsLoading(true); // API 호출 전에 로딩 상태 시작
+            setDataLoading(true); // 데이터 로딩 상태 true로 설정
+
             try {
                 const files = await pb.collection("files").getFullList(1, { autoCancel: false });
+
                 setFileData(files.map(file => ({
-                    id: file.id, // file.id 추가
+                    id: file.id,
                     imageUrl: getPbImageURL(file, "photo"),
                     name: file.name || "No name",
                     price: file.price || 0,
@@ -39,19 +46,22 @@ const FileList = ({ loggedInUserId }) => {
             } catch (error) {
                 console.error("Error fetching files:", error);
             } finally {
-                setIsLoading(false);
+                setIsLoading(false); // 전체 로딩 상태 해제
+                setDataLoading(false); // 데이터 로딩 완료, 대기 상태 해제
             }
         };
 
         fetchFiles();
-    }, []);
+    }, [loggedInUserId]);
 
-    if (isLoading) {
-        return <FileListSkeleton />; // Show skeleton UI while loading
+    // 데이터 로딩 중이면 스켈레톤 UI 표시
+    if (dataloading || isLoading) {
+        return <FileListSkeleton />;
     }
 
-    if (!fileData.length) {
-        return <p>No files available.</p>;
+    // 데이터가 로드 완료된 후 fileData가 비어 있을 경우만 "No files available." 메시지 표시
+    if (fileData.length === 0) {
+        return <p>제품이 비어있습니다.</p>;
     }
 
     return (
@@ -69,7 +79,7 @@ const FileList = ({ loggedInUserId }) => {
                                 width="800px"
                                 height="800px"
                                 className="w-full"
-                                />
+                            />
                         </figure>
                         <div className="flex flex-col">
                             <span className="text-sm font-bold dark:text-white">{file.name}</span>

--- a/src/components/FileList.jsx
+++ b/src/components/FileList.jsx
@@ -3,20 +3,26 @@ import pb from "../lib/pocketbase";
 import getPbImageURL from "../lib/getPbImageURL";
 import FileListSkeleton from "./FileListSkeleton";
 
-const FileList = () => {
+const FileList = ({ loggedInUserId }) => {
     const [fileData, setFileData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [favorites, setFavorites] = useState(() => {
-        // LocalStorage에서 찜 목록 초기화
-        const storedFavorites = localStorage.getItem("favorites");
+        const storedFavorites = localStorage.getItem(`favorites_${loggedInUserId}`);
         return storedFavorites ? JSON.parse(storedFavorites) : {};
     });
 
     const toggleFavorite = (id) => {
+        // 테스트 완료 후 활성
+        // if (!loggedInUserId) {
+        //     alert("로그인이 필요합니다.");
+        //     return;
+        // }
+
         setFavorites((prev) => {
             const updatedFavorites = { ...prev, [id]: !prev[id] };
-            localStorage.setItem("favorites", JSON.stringify(updatedFavorites)); // LocalStorage에 저장
+            localStorage.setItem(`favorites_${loggedInUserId}`, JSON.stringify(updatedFavorites)); // LocalStorage에 저장
             console.log(id)
+            console.log(loggedInUserId)
             return updatedFavorites;
         });
     };
@@ -25,12 +31,13 @@ const FileList = () => {
         const fetchFiles = async () => {
             try {
                 const files = await pb.collection("files").getFullList(1, { autoCancel: false });
-                setFileData(files.map(file => ({
-                    id: file.id, // file.id 추가
+                const formattedFiles = files.map((file) => ({
+                    id: file.id,
                     imageUrl: getPbImageURL(file, "photo"),
                     name: file.name || "No name",
                     price: file.price || 0,
-                })));
+                }));
+                setFileData(formattedFiles);
             } catch (error) {
                 console.error("Error fetching files:", error);
             } finally {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -20,6 +20,12 @@ function Header({ isLoggedIn, isdarkMode, setDarkMode }) {
                         FileList
                     </Link>
                 </li>
+                <li>
+                    <Link to="/06-react-vite-pocketbase/favorites" className="hover:underline">
+                        FavoriteFiles
+                    </Link>
+                </li>
+                
                 {!isLoggedIn && (
                     <>
                         <li>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,27 +1,48 @@
 import { Link } from "react-router-dom";
 import pb from "../lib/pocketbase";
+import { useEffect } from "react";
 
-function Header({ isLoggedIn, isdarkMode, setDarkMode }) {
+function Header({ isLoggedIn, isdarkMode, setDarkMode, isLoading, setIsLoading }) {
     const user = pb.authStore.model;
+
     const toggleDarkMode = () => {
         setDarkMode(!isdarkMode); // 다크모드 상태 반전
     };
+
+    useEffect(() => {
+        setIsLoading(true);
+        setTimeout(() => {
+            setIsLoading(false);
+        }, 500);
+    }, []);
 
     return (
         <nav className="fixed w-full p-4 bg-gray-200 dark:bg-gray-800">
             <ul className="flex gap-4 items-center text-black dark:text-white">
                 <li>
-                    <Link to="/" className="hover:underline">
+                    <Link 
+                        to="/"
+                        className="hover:underline"
+                        style={{ pointerEvents: isLoading ? 'none' : 'auto' }} // 로딩 중에는 클릭 방지
+                    >
                         Home
                     </Link>
                 </li>
                 <li>
-                    <Link to="/fileList" className="hover:underline">
+                    <Link
+                        to="/fileList" 
+                        className="hover:underline"
+                        style={{ pointerEvents: isLoading ? 'none' : 'auto' }} // 로딩 중에는 클릭 방지
+                    >
                         FileList
                     </Link>
                 </li>
                 <li>
-                    <Link to="/favorites" className="hover:underline">
+                    <Link 
+                        to="/favorites" 
+                        className="hover:underline"
+                        style={{ pointerEvents: isLoading ? 'none' : 'auto' }} // 로딩 중에는 클릭 방지
+                    >
                         FavoriteFiles
                     </Link>
                 </li>
@@ -29,12 +50,20 @@ function Header({ isLoggedIn, isdarkMode, setDarkMode }) {
                 {!isLoggedIn && (
                     <>
                         <li>
-                            <Link to="/login" className="hover:underline">
+                            <Link
+                                to="/login"
+                                className="hover:underline"
+                                style={{ pointerEvents: isLoading ? 'none' : 'auto' }} // 로딩 중에는 클릭 방지
+                            >
                                 Login
                             </Link>
                         </li>
                         <li>
-                            <Link to="/register" className="hover:underline">
+                            <Link 
+                                to="/register"
+                                className="hover:underline"
+                                style={{ pointerEvents: isLoading ? 'none' : 'auto' }} // 로딩 중에는 클릭 방지
+                            >
                                 Register
                             </Link>
                         </li>
@@ -48,6 +77,7 @@ function Header({ isLoggedIn, isdarkMode, setDarkMode }) {
                 <li>
                     <button
                         onClick={toggleDarkMode}
+                        disabled={isLoading} // 로딩 중 버튼 비활성화
                         className="px-4 py-2 bg-gray-300 border border-stone-400 dark:bg-gray-700 dark:border-gray-900 text-white rounded"
                     >
                         {isdarkMode ? "Light" : "Dark"}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -2,15 +2,15 @@ import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import pb from "../lib/pocketbase";
 
-const Home = ({ isLoggedIn, setIsLoggedIn }) => {
+const Home = ({ isLoggedIn, isdarkMode, setDarkMode, onLogout  }) => {
   const navigate = useNavigate();
 
-  // 로그아웃 처리 함수
-  function logout() {
-    pb.authStore.clear(); // 로그아웃 처리
-    setIsLoggedIn(false); // 로그인 상태 업데이트
-    localStorage.removeItem("isLoggedIn"); // 로컬스토리지에서 로그인 상태 제거
-  }
+  // // 로그아웃 처리 함수
+  // function logout() {
+  //   pb.authStore.clear(); // 로그아웃 처리
+  //   setIsLoggedIn(false); // 로그인 상태 업데이트
+  //   localStorage.removeItem("isLoggedIn"); // 로컬스토리지에서 로그인 상태 제거
+  // }
 
   // 로그인 상태에 따라 페이지 리디렉션
   useEffect(() => {
@@ -24,9 +24,9 @@ const Home = ({ isLoggedIn, setIsLoggedIn }) => {
       <h1 className="dark:text-white">Welcome to PocketBase Tutorial!</h1>
       {isLoggedIn && (
         <button
-          className="border rounded-md bg-gray-400 py-1 px-4"
-          onClick={logout}
-        >
+          onClick={onLogout}
+          className="border px-2 py-1 bg-red-500 text-white"
+      >
           Logout
         </button>
       )}


### PR DESCRIPTION
노션 : https://www.notion.so/170c969269d8803bb269dce44d9dcfe1?pvs=4

## 찜하기 기능 구현 + 로딩 상태
- **FavoriteFiles페이지**: 로그인 유저가 없다면 로그인이 필요하다는 경고창과 함께 로그인 페이지로 이동되도록 구현.
- **FileList의 찜하기 버튼**: 로그인 시에만 작동되도록 로그인이 필요합니다.
- **로딩 중 버튼 비활성화**: 새 브랜치를 팠어야하는데....🥲, 기존 브랜치에서 기능 구현 중에 header에서 로그인 상태 체크와 버튼 비활성화를 처리하면서, APP에서 상태 관리하도록 수정함.

---

### 발생한 문제

#### 1. **button을 누르면 모든 제품들의 button이 동시에 눌림**
- **console.log(id) 결과 `undefined`**
  - 현재 발생한 문제는 `favorites` 상태가 전체 제품을 기준으로 찜 상태를 관리하기 때문에, 모든 제품이 한 번에 업데이트됩니다. 각 제품의 찜 상태는 해당 제품의 `file.id`로 개별적으로 관리되어야 합니다.

  **해결 방안**
  - 각 제품에 `id`를 추가하여 `fileData` 배열에서 개별적으로 찜 상태를 관리합니다.
  - `toggleFavorite` 함수는 이제 각 제품의 `file.id`만 반전시킵니다. 이를 통해 각 제품의 찜 상태만 개별적으로 변경됩니다.
  - 찜 상태는 `localStorage`에 해당 제품의 `id`와 함께 관리됩니다.

  **수정 전 이미지**  
  ![수정 전 이미지](https://github.com/user-attachments/assets/4b0049cc-9251-4322-845d-d6c9afa77f81)

  **수정 후 이미지**  
  ![수정 후 이미지](https://github.com/user-attachments/assets/67ab2a2d-da8c-4273-85a3-d64d44384024)

  **왜 `undefined : false`가 보이는 걸까요?**
  - `favorites` 객체가 `undefined`일 때 `false`를 기본값으로 설정하고 있는 부분으로, 이는 `localStorage`에서 해당 제품의 `id`가 없을 때 `false`로 초기화되는 것입니다. 이 동작은 정상적입니다.

#### 2. **로그아웃 했을 때 `localStorage`에 찜 상태가 남아 있음**
  - **문제**: 로그아웃 후 `favoritesKey`가 `loggedInUserId`에 따라 유지되는 건 맞지만, 로그아웃 후 `localStorage`에서 사라지지 않고, 새로운 사용자가 로그인했을 때 찜 상태가 이전 사용자의 것으로 남습니다.

  **해결 방안**
  - 로그아웃 시 `localStorage`에서 해당 사용자의 `favoritesKey`를 삭제하고, 로그인 시 각 사용자의 `favoritesKey`가 다시 생성되도록 처리합니다.
  
  **로그아웃 상태의 `localStorage`**  
  ![로그아웃 상태의 localStorage](https://github.com/user-attachments/assets/2042f331-80dd-45dc-8494-32acdc688c66)

  **로그인 후 생성되는 `localStorage`**  
  ![로그인 후 생성되는 localStorage](https://github.com/user-attachments/assets/8ffd1a00-5296-4722-a501-8fc7df08aac1)

#### 3. **⭐️ 데이터를 받아오는 중에 에러 메시지가 표시됨**
  - **문제**: 비동기적으로 데이터를 불러오는 동안 `fileData`가 아직 비어있는 상태일 수 있습니다. 이때, "데이터가 비어 있다"는 메시지가 계속 보이는 오류가 발생합니다.

  **해결 방안**
  1. **로딩 상태와 데이터 상태 분리**: `isLoading`은 전체적인 로딩 상태를 관리하고, `fileData`의 상태가 완전히 로드되었는지 여부를 관리하는 별도의 상태를 추가해야 합니다.
  2. **`fileData`가 비어있는 경우 처리**: `fileData`가 완전히 로드된 후에만 `"No files available."` 메시지를 표시하고, 로딩 중인 상태에서는 로딩 UI (`FileListSkeleton`)을 표시하는 방식으로 관리해야 합니다.
  3. **네트워크 요청 중인지 체크**: `fetch`가 완료되었을 때만 `fileData`의 상태를 업데이트하고, 그 전에 `"No files available"` 메시지가 나타나지 않도록 합니다.

  **주요 변경 사항**
  - **`loading` 상태 추가**: `loading` 상태를 추가하여 데이터 로딩 여부를 체크합니다. 이 값은 `fetchFiles` 함수가 완료된 후에 `false`로 설정됩니다.
  - **로딩 중일 때**: `loading`이 `true`일 때는 `<FileListSkeleton />`을 표시하여 로딩 UI를 보여줍니다.
  - **데이터 로딩 후 처리**: 데이터가 로드 완료된 후, `fileData.length === 0`인 경우에만 `"No files available."` 메시지를 표시합니다. 로딩 중일 때는 이 메시지가 보이지 않도록 처리합니다.
  - **데이터 처리**: `fileData`가 비어있지 않은 상태에서만 실제 데이터를 렌더링하도록 처리합니다.

---

### **결론**
- **로딩 중일 때**: 스켈레톤 UI를 표시하여 사용자에게 로딩 상태를 알려줍니다.
- **데이터가 로딩된 후 비어있을 때**: `"No files available."` 메시지를 표시하여 데이터가 없는 상태를 처리합니다.
- **데이터가 제대로 로드되었을 때**: 파일 리스트를 표시하여 사용자가 볼 수 있도록 합니다.

### 해결하지 못한 문제
#### 1. **찜한파일 불러올 때**
**내가 하고싶은 것**
로컬 스토리지에서 찜한 파일 목록을 관리하고 있으며
성능을 개선하기 위해 FavoriteFiles에서 전체 파일을 불러오는 것 대신 이미 로컬에 찜 목록이 있을 경우 해당 파일만 서버에서 불러오!!
따라서 FavoriteFiles 컴포넌트는 찜한 파일만 가져오고, FileList는 모든 파일을 가져오도록 한다.
