### PR TITLE
컴포넌트 분리 및 리팩토링

### DIFF
--- a/src/hooks/useImageViewer.js
+++ b/src/hooks/useImageViewer.js
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+const useImageViewer = () => {
+    const [selectedImage, setSelectedImage] = useState(null);
+
+    const handleImageClick = (img, post, isExistingImage) => {
+        let imgSrc;
+        if (isExistingImage && post) {
+            imgSrc = `${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`;
+        } else {
+            imgSrc = img;
+        }
+        setSelectedImage(imgSrc);
+    };
+
+    return { selectedImage, setSelectedImage, handleImageClick };
+};
+
+export default useImageViewer;

--- a/src/pages/PostEditModal.jsx
+++ b/src/pages/PostEditModal.jsx
@@ -1,0 +1,188 @@
+import React, { useState, useRef } from "react";
+import pb from "../lib/pocketbase";
+import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
+import PostImageModal from "./PostImageModal";
+
+const PostEditModal = ({ editPost, setEditPost, setEditModal, fetchPosts }) => {
+    const fileInputRef = useRef(null);
+    const [title, setTitle] = useState(editPost.title);
+    const [text, setText] = useState(editPost.text);
+    const [postImgs, setPostImgs] = useState([]);
+    const [previewImgs, setPreviewImgs] = useState([]);
+    const [uploading, setUploading] = useState(false);
+    const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer(); // 🔥 커스텀 훅 사용
+
+    // 🔹 파일 업로드 핸들러
+    const uploadFiles = (e) => {
+        const files = Array.from(e.target.files);
+        if ((editPost?.field?.length || 0) + postImgs.length + files.length > 3) {
+            alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
+            return;
+        }
+        const newPreviewImgs = files.map(file => URL.createObjectURL(file));
+        setPostImgs(prev => [...prev, ...files].slice(0, 3 - (editPost?.field?.length || 0)));
+        setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3 - (editPost?.field?.length || 0)));
+
+        // ✅ 파일 선택 후 `input` 값 초기화
+        if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+        }
+    };
+
+    // 🔹 파일 선택 버튼 클릭 시 파일 입력 창 열기
+    const handleFileButtonClick = () => {
+        if (fileInputRef.current) {
+            fileInputRef.current.click();
+        }
+    };
+
+    // 🔹 미리보기 이미지 삭제 핸들러
+    const removePreviewImage = (index) => {
+        setPreviewImgs(prev => prev.filter((_, i) => i !== index));
+        setPostImgs(prev => prev.filter((_, i) => i !== index));
+    };
+
+    // 🔹 기존 이미지 삭제 핸들러
+    const removeExistingImage = (index) => {
+        if (editPost.field.length <= 1) {
+            alert("최소 1개의 이미지는 있어야 합니다.");
+            return;
+        }
+        const updatedImages = editPost.field.filter((_, i) => i !== index);
+        setEditPost({ ...editPost, field: updatedImages });
+    };
+
+    // 🔹 게시물 수정 핸들러
+    const handleUpdate = async (e) => {
+        e.preventDefault();
+        setUploading(true);
+        try {
+            const formData = new FormData();
+            formData.append("title", title);
+            formData.append("text", text);
+
+            // ✅ 기존 이미지 추가
+            if (editPost.field) {
+                editPost.field.forEach((img) => formData.append("field", img));
+            }
+
+            // ✅ 새로운 이미지 추가
+            postImgs.forEach((img) => formData.append("field", img));
+
+            await pb.collection("post").update(editPost.id, formData);
+
+            fetchPosts();
+            setEditModal(false);
+        } catch (error) {
+            console.error("게시물 수정 실패:", error);
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 bg-gray-800 bg-opacity-10 flex justify-center items-center z-10">
+            <div className="bg-white p-4 rounded shadow-lg w-96">
+                <h2 className="text-lg font-bold">게시물 수정</h2>
+                <form onSubmit={handleUpdate} className="mt-4">
+                    <input 
+                        type="text" 
+                        value={title} 
+                        onChange={(e) => setTitle(e.target.value)} 
+                        placeholder="제목 입력" 
+                        className="w-full p-2 border rounded"
+                    />
+                    <textarea 
+                        value={text} 
+                        onChange={(e) => setText(e.target.value)} 
+                        placeholder="내용 입력" 
+                        className="w-full p-2 border rounded mt-2"
+                    />
+
+                    {/* ✅ 파일 입력 필드 */}
+                    <input 
+                        type="file" 
+                        ref={fileInputRef} 
+                        onChange={uploadFiles} 
+                        hidden // ✅ 완전히 숨김
+                        multiple 
+                        accept="image/*" 
+                    />
+                    <button 
+                        type="button" 
+                        onClick={handleFileButtonClick} 
+                        className="px-4 py-2 bg-blue-500 text-white rounded cursor-pointer hover:bg-blue-600 mt-2"
+                    >
+                        파일 선택
+                    </button>
+
+                    {/* ✅ 기존 이미지 미리보기 */}
+                    <div className="mt-2 flex space-x-2">
+                        {editPost?.field?.map((img, index) => (
+                            <div key={index} className="relative">
+                                <img
+                                    src={`${import.meta.env.VITE_PB_API}/files/${editPost.collectionId}/${editPost.id}/${img}`} 
+                                    alt="기존 이미지"
+                                    className="w-20 h-20 object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                    onClick={() => handleImageClick(img, editPost, true)}
+                                />
+                                <button 
+                                    type="button"
+                                    onClick={() => removeExistingImage(index)} 
+                                    className="absolute top-0 right-0 bg-red-500 text-white p-1 rounded-full"
+                                >
+                                    X
+                                </button>
+                            </div>
+                        ))}
+                        {/* ✅ 새로운 업로드 이미지 미리보기 */}
+                        {previewImgs.map((img, index) => (
+                            <div key={index} className="relative">
+                                <img 
+                                    src={img} 
+                                    alt="미리보기" 
+                                    onClick={() => handleImageClick(img, null, false)}
+                                    className="w-20 h-20 object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                />
+                                <button 
+                                    type="button"
+                                    onClick={() => removePreviewImage(index)} 
+                                    className="absolute top-0 right-0 bg-red-500 text-white p-1 rounded-full"
+                                >
+                                    X
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* ✅ 수정 버튼 */}
+                    <button 
+                        type="submit"
+                        className="mt-4 px-4 py-2 w-full bg-green-500 text-white rounded hover:bg-green-600"
+                        disabled={uploading}
+                    >
+                        {uploading ? "업로드 중..." : "수정 완료"}
+                    </button>
+
+                    {/* ✅ 취소 버튼 */}
+                    <button 
+                        type="button"
+                        onClick={() => setEditModal(false)} 
+                        className="mt-2 px-4 py-2 bg-gray-500 text-white rounded w-full"
+                    >
+                        취소
+                    </button>
+                </form>
+            </div>
+            {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}
+                        {selectedImage && (
+                <PostImageModal 
+                    selectedImage={selectedImage} 
+                    setSelectedImage={setSelectedImage} 
+                />
+            )}
+        </div>
+    );
+};
+
+export default PostEditModal;

--- a/src/pages/PostImageModal.jsx
+++ b/src/pages/PostImageModal.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+const PostImageModal = ({ selectedImage, setSelectedImage }) => {
+    if (!selectedImage) return null; // 선택된 이미지가 없으면 렌더링하지 않음
+
+    return (
+        <div 
+            className="p-6 fixed inset-0 bg-black bg-opacity-75 flex justify-center items-center z-20" 
+            onClick={(e) => e.stopPropagation()} // 배경 클릭 시 모달 닫기
+        >
+            <div className="relative" onClick={(e) => e.stopPropagation()}> {/* 내부 클릭 시 닫히지 않도록 설정 */}
+                <img 
+                    src={selectedImage} 
+                    alt="확대된 이미지" 
+                    className="max-w-full max-h-screen rounded"
+                />
+                <button
+                    className="absolute top-4 right-4 bg-white p-2 rounded-full hover:bg-slate-300"
+                    onClick={(e) => {
+                        e.stopPropagation(); // 부모 `div`의 클릭 이벤트 전파 방지
+                        setSelectedImage(null); // 모달 닫기
+                    }}
+                >
+                    X
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default PostImageModal;

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect } from "react";
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import pb from "../lib/pocketbase";
+import { Navigation } from 'swiper/modules';
+import PostEditModal from "./PostEditModal";
+import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
+import PostImageModal from "./PostImageModal";
+
+
+const PostItem = ({ 
+    user, 
+    post, 
+    fetchPosts, 
+    editPost, 
+    setEditPost, 
+    editModal, 
+    setEditModal, 
+    // handleImageClick, // ✅ 부모에서 handleImageClick 전달받음
+    isMobile, 
+    setIsMobile 
+}) => {
+    const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer(); // 🔥 커스텀 훅 사용
+    
+    useEffect(() => {
+        const handleResize = () => setIsMobile(window.innerWidth <= 500);
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
+
+    // 🔹 게시물 삭제 함수 (유저와 작성자가 일치하는 경우에만 가능)
+    const handleDelete = async (post) => {
+        if (post.editor !== user.name) {
+            alert("삭제할 권한이 없습니다.");
+            return;
+        }
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+
+        try {
+            await pb.collection("post").delete(post.id);
+            fetchPosts();
+        } catch (error) {
+            console.error("게시물 삭제 실패:", error);
+        }
+    };
+
+    // 🔹 게시물 수정 모달 열기
+    const handleEdit = (post) => {
+        setEditPost(post); 
+        setEditModal(true); 
+    };
+
+    return (
+        <li className="border p-4 mb-2 rounded">
+            <p className="font-bold">{post.editor}님</p>
+            <p>{post.title}</p>
+            <p>{post.text}</p>
+            <p className="text-sm text-gray-500">{new Date(post.updated).toISOString().split("T")[0]}</p>
+
+            {post.field && Array.isArray(post.field) ? (
+                <div>
+                    {isMobile ? (
+                        <Swiper navigation modules={[Navigation]} className="">
+                            {post.field.map((img, index) => (
+                                <SwiperSlide key={index}>
+                                    <img 
+                                        src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
+                                        alt={post.title} 
+                                        className="aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                        onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                    />
+                                </SwiperSlide>
+                            ))}
+                        </Swiper>
+                    ) : (
+                        <div className="flex space-x-2 bg-blue-400">
+                            {post.field.map((img, index) => (
+                                <img 
+                                    key={index} 
+                                    src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
+                                    alt={post.title} 
+                                    className="w-[32.5%] md:w-[32.8%] aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80" 
+                                    onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            ) : null}
+
+            {post.editor === user.name && (
+                <>
+                    <button 
+                        onClick={() => handleEdit(post)} 
+                        className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded">
+                        수정
+                    </button>
+                    <button 
+                        onClick={() => handleDelete(post)} 
+                        className="ml-2 px-2 py-1 bg-red-500 text-white rounded">
+                        삭제
+                    </button>
+                </>
+            )}
+
+            {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}
+            {selectedImage && (
+                <PostImageModal 
+                    selectedImage={selectedImage} 
+                    setSelectedImage={setSelectedImage} 
+                />
+            )}
+
+            {editModal && editPost && (
+                <PostEditModal 
+                    editPost={editPost} 
+                    setEditPost={setEditPost} 
+                    setEditModal={setEditModal} 
+                    fetchPosts={fetchPosts} 
+                />
+            )}
+        </li>
+    );
+};
+
+export default PostItem;

--- a/src/pages/PostList.jsx
+++ b/src/pages/PostList.jsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from "react";
+import PostItem from "./PostItem";
+
+const PostList = ({ 
+    user, 
+    postData, 
+    editPost, 
+    setEditPost, 
+    editModal, 
+    setEditModal, 
+    fetchPosts, 
+    isMobile, 
+    setIsMobile,
+    isLoading,
+    isDataLoaded,
+}) => {
+    const [searchQuery, setSearchQuery] = useState("");
+    const [filterOption, setFilterOption] = useState("all");
+    const [filteredPosts, setFilteredPosts] = useState([...postData]);
+    
+    // 🔹 컴포넌트가 마운트되거나 postData가 변경될 때 기본 필터 적용
+    useEffect(() => {
+        if (isDataLoaded) {
+            filterPosts(searchQuery, filterOption);
+        }
+    }, [postData, isDataLoaded]); // ✅ postData 변경 시 필터 적용
+
+    const handleSearch = (e) => {
+        const query = e.target.value.toLowerCase();
+        setSearchQuery(query);
+        filterPosts(query, filterOption);
+    };
+
+    const handleFilterChange = (e) => {
+        const selectedOption = e.target.value;
+        setFilterOption(selectedOption);
+        filterPosts(searchQuery, selectedOption);
+    };
+
+    const filterPosts = (query, filter) => {
+        let filtered = [...postData];
+
+        if (filter === "myPosts") {
+            filtered = filtered.filter(post => post.editor === user.name);
+        } else if (filter === "latest") {
+            filtered = filtered.sort((a, b) => new Date(b.created) - new Date(a.created));
+        }
+
+        if (query) {
+            filtered = filtered.filter(post => 
+                post.title.toLowerCase().includes(query) || 
+                post.text.toLowerCase().includes(query)
+            );
+        }
+
+        setFilteredPosts(filtered);
+    };
+
+    return (
+        <div className="w-full max-w-2xl">
+            <div className="flex gap-4 mt-4">
+                <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={handleSearch}
+                    placeholder="검색어를 입력하세요"
+                    className="w-full p-2 border rounded"
+                />
+                <select onChange={handleFilterChange} value={filterOption} className="px-4 py-2 border rounded">
+                    <option value="all">기본 보기</option>
+                    <option value="myPosts">내 게시물 보기</option>
+                    <option value="latest">최신 글 보기</option>
+                </select>
+            </div>
+
+            <ul className="mt-4 w-full">
+                    {filteredPosts.map((post) => (
+                        <PostItem 
+                            key={post.id} 
+                            user={user}
+                            post={post}
+                            fetchPosts={fetchPosts} 
+                            editPost={editPost}
+                            editModal={editModal}
+                            setEditPost={setEditPost}
+                            setEditModal={setEditModal}
+                            isMobile={isMobile}
+                            setIsMobile={setIsMobile}
+                        />
+                    ))}
+            </ul>
+
+            {/* 🔹 로딩 중 상태 표시 */}
+            {isLoading && (
+                <p className="text-center text-gray-500 mt-4">데이터를 불러오는 중...</p>
+            )}
+
+            {/* 🔹 데이터가 로드 완료되었지만 게시물이 없는 경우 */}
+            {!isLoading && isDataLoaded && filteredPosts.length === 0 && (
+                <p className="text-center text-gray-500 mt-4">게시물이 없습니다.</p>
+            )}
+        </div>
+    );
+};
+
+export default PostList;
+

--- a/src/pages/PostModal.jsx
+++ b/src/pages/PostModal.jsx
@@ -1,0 +1,149 @@
+import React, { useState, useRef } from "react";
+import pb from "../lib/pocketbase";
+import PostImageModal from "./PostImageModal";
+import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
+
+const PostModal = ({ post, setShowForm, fetchPosts }) => {
+    const user = pb.authStore.model;
+    const fileInputRef = useRef(null);
+    const [title, setTitle] = useState(post ? post.title : "");
+    const [text, setText] = useState(post ? post.text : "");
+    const [postImgs, setPostImgs] = useState([]);
+    const [previewImgs, setPreviewImgs] = useState([]);
+    const [uploading, setUploading] = useState(false);
+    const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer();
+
+
+    const uploadFiles = (e) => {
+        const files = Array.from(e.target.files);
+        if ((post?.field?.length || 0) + postImgs.length + files.length > 3) {
+            alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
+            return;
+        }
+        const newPreviewImgs = files.map(file => URL.createObjectURL(file));
+        setPostImgs(prev => [...prev, ...files].slice(0, 3));
+        setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3));
+    };
+
+    const removePreviewImage = (index) => {
+        setPreviewImgs(prev => prev.filter((_, i) => i !== index));
+        setPostImgs(prev => prev.filter((_, i) => i !== index));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!title || !text || postImgs.length === 0 || !user) {
+            alert("제목, 내용, 이미지를 모두 입력해주세요.");
+            return;
+        }
+        setUploading(true);
+        try {
+            const formData = new FormData();
+            formData.append("title", title);
+            formData.append("text", text);
+            formData.append("editor", user.name);
+            formData.append("user", user.id);
+            formData.append("updated", new Date().toISOString().split("T")[0]);
+
+            postImgs.forEach((img) => formData.append("field", img));
+
+            if (post) {
+                await pb.collection("post").update(post.id, formData);
+            } else {
+                await pb.collection("post").create(formData);
+            }
+
+            fetchPosts();
+            setShowForm(false);
+        } catch (error) {
+            console.error("게시물 저장 실패:", error);
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    return (
+        <div className="z-10 p-4 fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center">
+            <div className="bg-white p-4 rounded shadow-lg w-96">
+                <h2 className="text-lg font-bold">게시물 작성</h2>
+                <form onSubmit={handleSubmit} className="mt-4">
+                    <input 
+                        type="text" 
+                        value={title} 
+                        onChange={(e) => setTitle(e.target.value)} 
+                        placeholder="제목 입력" 
+                        className="w-full p-2 border rounded"
+                    />
+                    <textarea 
+                        value={text} 
+                        onChange={(e) => setText(e.target.value)} 
+                        placeholder="내용 입력" 
+                        className="w-full p-2 border rounded mt-2"
+                    />
+                    <input 
+                        type="file" 
+                        ref={fileInputRef} 
+                        onChange={uploadFiles} 
+                        className="opacity-0 absolute w-0 h-0" // ✅ 파일 입력 필드 숨김 (하지만 클릭 가능)
+                        multiple 
+                        accept="image/*" 
+                        id="fileUpload"
+                    />
+                    <label 
+                        htmlFor="fileUpload" 
+                        className="px-4 py-2 bg-blue-500 text-white rounded cursor-pointer hover:bg-blue-600 inline-block"
+                    >
+                        파일 선택
+                    </label>
+
+                    {/* 업로드한 이미지 미리보기 */}
+                    <div className="mt-2 flex space-x-2">
+                        {previewImgs.map((img, index) => (
+                            <div key={index} className="relative">
+                                <img 
+                                    src={img} 
+                                    alt="미리보기" 
+                                    onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                    className="w-20 h-20 object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                />
+                                <button 
+                                    type="button"
+                                    onClick={() => removePreviewImage(index)} 
+                                    className="absolute top-0 right-0 bg-red-500 text-white p-1 rounded-full">X
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* ✅ 작성하기 & 취소 버튼 추가 */}
+                    <button 
+                        type="submit" 
+                        className={`mt-4 px-4 py-2 rounded w-full ${
+                            title && text && postImgs.length > 0 ? "bg-green-500 text-white hover:bg-green-600" : "bg-gray-400 text-gray-200 cursor-not-allowed"
+                        }`} 
+                        disabled={!title || !text || postImgs.length === 0 || uploading}
+                    >
+                        {uploading ? "업로드 중..." : "게시하기"}
+                    </button>
+                    <button 
+                        type="button" 
+                        onClick={() => setShowForm(false)} 
+                        className="mt-2 px-4 py-2 bg-gray-500 text-white rounded w-full"
+                    >
+                        취소
+                    </button>
+                </form>
+            </div>
+
+            {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}
+            {selectedImage && (
+                <PostImageModal 
+                    selectedImage={selectedImage} 
+                    setSelectedImage={setSelectedImage} 
+                />
+            )}
+        </div>
+    );
+};
+
+export default PostModal;


### PR DESCRIPTION
## 📌 1. 컴포넌트 분리
컴포넌트를 역할별로 분리하여 유지보수성을 높였습니다.
```
📂 src
 ┣ 📂 components
 ┃ ┣ 📜 Post.jsx           // 메인 게시판 컴포넌트
 ┃ ┣ 📜 PostList.jsx       // 게시물 목록을 관리하는 컴포넌트
 ┃ ┣ 📜 PostItem.jsx       // 개별 게시물을 렌더링하는 컴포넌트
 ┃ ┣ 📜 PostModal.jsx      // 게시물 작성 모달
 ┃ ┣ 📜 PostEditModal.jsx  // 게시물 수정 모달
 ┃ ┣ 📜 PostImageModal.jsx // 이미지 확대 모달
 ┣ 📂 hooks
 ┃ ┣ 📜 useImageViewer.js  // 이미지 확대 기능을 담당하는 커스텀 훅
```

## 🚀 2. useImageViewer 커스텀 훅 추가
📌 src/hooks/useImageViewer.js 파일에서 selectedImage, setSelectedImage, handleImageClick 기능을 관리하는 커스텀 훅을 추가하였습니다.
해당 훅은 이미지 클릭 시 기존 이미지와 새 이미지의 URL을 구분하여 설정할 수 있도록 합니다.

✅ useImageViewer.js
```
import { useState } from "react";

const useImageViewer = () => {
    const [selectedImage, setSelectedImage] = useState(null);

    const handleImageClick = (img, post, isExistingImage) => {
        let imgSrc;
        if (isExistingImage && post) {
            imgSrc = `${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`;
        } else {
            imgSrc = img;
        }
        setSelectedImage(imgSrc);
    };

    return { selectedImage, setSelectedImage, handleImageClick };
};

export default useImageViewer;
```

