### PR TITLE
게시물 상세페이지

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Home from "./pages/Home"; // Home 컴포넌트 추가
 import FileList from "./pages/FileList";
 import FavoriteFiles from "./pages/FavoriteFiles";
 import Post from "./pages/Post";
+import PostDetail from "./pages/PostDetail";
 
 function App() {
     const [isLoading, setIsLoading] = useState(false); // 로딩 상태 관리
@@ -114,6 +115,7 @@ function App() {
                         path="/post"
                         element={<Post isLoggedIn={isLoggedIn}  loggedInUserId={loggedInUserId} isLoading={isLoading} setIsLoading={setIsLoading}/>}
                     />
+                    <Route path="/post/:id" element={<PostDetail />} />
                 </Route>
             </Routes>
         </Router>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import "swiper/css/navigation";
+import { Navigation } from "swiper/modules";
+
+const PostContent = ({ user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+    return (
+        <div>
+            <h2 className="text-xl font-bold">{post.title}</h2>
+            <p className="text-gray-700">{post.text}</p>
+            <p className="text-sm text-gray-500">
+                {new Date(post.updated).toISOString().split("T")[0]}
+            </p>
+            
+            {/* 이미지 슬라이더 */}
+            {post.field && Array.isArray(post.field) ? (
+                <div>
+                    {isMobile ? (
+                        <Swiper navigation modules={[Navigation]} className="">
+                            {post.field.map((img, index) => (
+                                <SwiperSlide key={index}>
+                                    <img 
+                                        src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
+                                        alt={post.title} 
+                                        className="aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                        onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                    />
+                                </SwiperSlide>
+                            ))}
+                        </Swiper>
+                    ) : (
+                        <div className="flex space-x-2 bg-blue-400">
+                            {post.field.map((img, index) => (
+                                <img 
+                                    key={index} 
+                                    src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
+                                    alt={post.title} 
+                                    className="w-[32.5%] md:w-[32.8%] aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80" 
+                                    onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            ) : null}
+
+            {post && user && post.editor === user.name && (
+                <>
+                    <button 
+                        onClick={(e) => {
+                            e.stopPropagation(); // 부모의 onClick 실행 방지
+                            handleEdit(post);
+                        }}
+                        className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded">
+                        수정
+                    </button>
+                    <button 
+                        onClick={(e) => {
+                            e.stopPropagation(); // 부모의 onClick 실행 방지
+                            handleDelete(post);
+                        }}
+                        className="ml-2 px-2 py-1 bg-red-500 text-white rounded">
+                        삭제
+                    </button>
+                </>
+            )}
+
+        </div>
+    );
+};
+
+export default PostContent;

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -4,18 +4,23 @@ import "swiper/css";
 import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
 
-const PostContent = ({ user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+const PostContent = ({ onClick, user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+
     return (
         <div>
-            <h2 className="text-xl font-bold">{post.title}</h2>
-            <p className="text-gray-700">{post.text}</p>
-            <p className="text-sm text-gray-500">
-                {new Date(post.updated).toISOString().split("T")[0]}
-            </p>
+            <div className="mb-2">
+                <p className="font-bold text-gray-700 mb-2">{post.editor}님</p>
+                <h2 className="text-xl font-bold">{post.title}</h2>
+                <p className="text-gray-700 mb-2">{post.text}</p>
+                <p className="text-sm text-gray-500">
+                    {new Date(post.updated).toISOString().split("T")[0]}
+                </p>
+            </div>
             
             {/* 이미지 슬라이더 */}
             {post.field && Array.isArray(post.field) ? (
-                <div>
+                <div onClick={onClick}  // ✅ 부모 이벤트 방지 적용
+                > 
                     {isMobile ? (
                         <Swiper navigation modules={[Navigation]} className="">
                             {post.field.map((img, index) => (
@@ -46,26 +51,20 @@ const PostContent = ({ user, post, handleImageClick, isMobile, handleDelete, han
             ) : null}
 
             {post && user && post.editor === user.name && (
-                <>
+                <div onClick={onClick}  // ✅ 부모 이벤트 방지 적용
+                >
                     <button 
-                        onClick={(e) => {
-                            e.stopPropagation(); // 부모의 onClick 실행 방지
-                            handleEdit(post);
-                        }}
+                        onClick={() => handleEdit(post)} 
                         className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded">
                         수정
                     </button>
                     <button 
-                        onClick={(e) => {
-                            e.stopPropagation(); // 부모의 onClick 실행 방지
-                            handleDelete(post);
-                        }}
+                        onClick={() => handleDelete(post)} 
                         className="ml-2 px-2 py-1 bg-red-500 text-white rounded">
                         삭제
                     </button>
-                </>
+                </div>
             )}
-
         </div>
     );
 };

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import pb from "../lib/pocketbase";
+
+const PostDetail = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [post, setPost] = useState(null);
+    const [comments, setComments] = useState([]);
+    const [newComment, setNewComment] = useState("");
+
+    useEffect(() => {
+        fetchPost();
+        fetchComments();
+    }, []);
+
+    const fetchPost = async () => {
+        try {
+            const postData = await pb.collection("post").getOne(id);
+            setPost(postData);
+        } catch (error) {
+            console.error("게시물 로드 실패:", error);
+        }
+    };
+
+    const fetchComments = async () => {
+        try {
+            const commentsData = await pb.collection("comments").getFullList({
+                filter: `post="${id}"`,
+            });
+            setComments(commentsData);
+        } catch (error) {
+            console.error("댓글 로드 실패:", error);
+        }
+    };
+
+    const handleAddComment = async () => {
+        if (!newComment.trim()) return;
+
+        try {
+            const newCommentData = await pb.collection("comments").create({
+                post: id,
+                text: newComment,
+            });
+            setComments([...comments, newCommentData]);
+            setNewComment("");
+        } catch (error) {
+            console.error("댓글 추가 실패:", error);
+        }
+    };
+
+    const handleDeleteComment = async (commentId) => {
+        if (!window.confirm("댓글을 삭제하시겠습니까?")) return;
+
+        try {
+            await pb.collection("comments").delete(commentId);
+            setComments(comments.filter((c) => c.id !== commentId));
+        } catch (error) {
+            console.error("댓글 삭제 실패:", error);
+        }
+    };
+
+    if (!post) return <p>게시물을 불러오는 중...</p>;
+
+    return (
+        <div className="max-w-2xl mx-auto p-4">
+            <button onClick={() => navigate(-1)} className="text-blue-500 mb-4">← 뒤로가기</button>
+            <h2 className="text-xl font-bold">{post.title}</h2>
+            <p className="text-gray-700">{post.text}</p>
+
+            <div className="mt-6">
+                <h3 className="text-lg font-bold">댓글 ({comments.length})</h3>
+                <div className="mt-2">
+                    {comments.map((comment) => (
+                        <div key={comment.id} className="border p-2 mt-2 flex justify-between">
+                            <p>{comment.text}</p>
+                            <button onClick={() => handleDeleteComment(comment.id)} className="text-red-500">삭제</button>
+                        </div>
+                    ))}
+                </div>
+                <input
+                    type="text"
+                    value={newComment}
+                    onChange={(e) => setNewComment(e.target.value)}
+                    placeholder="댓글을 입력하세요"
+                    className="w-full p-2 border mt-2"
+                />
+                <button onClick={handleAddComment} className="mt-2 bg-blue-500 text-white px-4 py-2 rounded">댓글 작성</button>
+            </div>
+        </div>
+    );
+};
+
+export default PostDetail;

--- a/src/pages/PostEditModal.jsx
+++ b/src/pages/PostEditModal.jsx
@@ -3,7 +3,7 @@ import pb from "../lib/pocketbase";
 import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
 import PostImageModal from "./PostImageModal";
 
-const PostEditModal = ({ editPost, setEditPost, setEditModal, fetchPosts }) => {
+const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPosts }) => {
     const fileInputRef = useRef(null);
     const [title, setTitle] = useState(editPost.title);
     const [text, setText] = useState(editPost.text);
@@ -81,7 +81,10 @@ const PostEditModal = ({ editPost, setEditPost, setEditModal, fetchPosts }) => {
     };
 
     return (
-        <div className="fixed inset-0 bg-gray-800 bg-opacity-10 flex justify-center items-center z-10">
+        <div 
+            onClick={onClick}
+            className="fixed inset-0 bg-gray-800 bg-opacity-10 flex justify-center items-center z-10"
+        >
             <div className="bg-white p-4 rounded shadow-lg w-96">
                 <h2 className="text-lg font-bold">게시물 수정</h2>
                 <form onSubmit={handleUpdate} className="mt-4">

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -1,14 +1,11 @@
 import React, { useEffect } from "react";
-import { Swiper, SwiperSlide } from 'swiper/react';
-import 'swiper/css';
-import 'swiper/css/navigation';
 import pb from "../lib/pocketbase";
 import { Navigation } from 'swiper/modules';
 import PostEditModal from "./PostEditModal";
 import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
 import PostImageModal from "./PostImageModal";
 import { useNavigate } from "react-router-dom";
-
+import PostContent from "./PostContent";
 
 const PostItem = ({ 
     user, 
@@ -18,7 +15,6 @@ const PostItem = ({
     setEditPost, 
     editModal, 
     setEditModal, 
-    // handleImageClick, // ✅ 부모에서 handleImageClick 전달받음
     isMobile, 
     setIsMobile 
 }) => {
@@ -55,60 +51,18 @@ const PostItem = ({
 
     return (
         <li 
-            className="border p-4 mb-2 rounded"
-            onClick={() => navigate(`/post/${post.id}`)}
+            className="border p-4 mb-2 rounded cursor-pointer hover:bg-slate-100"
+            onClick={() => navigate(`/post/${post.id}`)} // ✅ `state`로 값 전달
         >
-            <p className="font-bold">{post.editor}님</p>
-            <p>{post.title}</p>
-            <p>{post.text}</p>
-            <p className="text-sm text-gray-500">{new Date(post.updated).toISOString().split("T")[0]}</p>
-            <p className="text-sm text-blue-500">댓글 {post.commentCount || 0}개</p>
-            
-            {post.field && Array.isArray(post.field) ? (
-                <div>
-                    {isMobile ? (
-                        <Swiper navigation modules={[Navigation]} className="">
-                            {post.field.map((img, index) => (
-                                <SwiperSlide key={index}>
-                                    <img 
-                                        src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
-                                        alt={post.title} 
-                                        className="aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
-                                        onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
-                                    />
-                                </SwiperSlide>
-                            ))}
-                        </Swiper>
-                    ) : (
-                        <div className="flex space-x-2 bg-blue-400">
-                            {post.field.map((img, index) => (
-                                <img 
-                                    key={index} 
-                                    src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
-                                    alt={post.title} 
-                                    className="w-[32.5%] md:w-[32.8%] aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80" 
-                                    onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
-                                />
-                            ))}
-                        </div>
-                    )}
-                </div>
-            ) : null}
-
-            {post.editor === user.name && (
-                <>
-                    <button 
-                        onClick={() => handleEdit(post)} 
-                        className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded">
-                        수정
-                    </button>
-                    <button 
-                        onClick={() => handleDelete(post)} 
-                        className="ml-2 px-2 py-1 bg-red-500 text-white rounded">
-                        삭제
-                    </button>
-                </>
-            )}
+            <PostContent 
+                onClick={(e) => e.stopPropagation()} /* ✅ 부모 이벤트 방지 적용 */
+                post={post} 
+                user={user} 
+                isMobile={isMobile}
+                handleDelete={handleDelete} 
+                handleEdit={handleEdit}
+                handleImageClick={handleImageClick}
+            />
 
             {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}
             {selectedImage && (
@@ -120,6 +74,7 @@ const PostItem = ({
 
             {editModal && editPost && (
                 <PostEditModal 
+                    onClick={(e) => e.stopPropagation()} /* ✅ 부모 이벤트 방지 적용 */
                     editPost={editPost} 
                     setEditPost={setEditPost} 
                     setEditModal={setEditModal} 

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -7,6 +7,7 @@ import { Navigation } from 'swiper/modules';
 import PostEditModal from "./PostEditModal";
 import useImageViewer from "../hooks/useImageViewer"; // 🔥 커스텀 훅 추가
 import PostImageModal from "./PostImageModal";
+import { useNavigate } from "react-router-dom";
 
 
 const PostItem = ({ 
@@ -22,6 +23,7 @@ const PostItem = ({
     setIsMobile 
 }) => {
     const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer(); // 🔥 커스텀 훅 사용
+    const navigate = useNavigate();
     
     useEffect(() => {
         const handleResize = () => setIsMobile(window.innerWidth <= 500);
@@ -52,12 +54,16 @@ const PostItem = ({
     };
 
     return (
-        <li className="border p-4 mb-2 rounded">
+        <li 
+            className="border p-4 mb-2 rounded"
+            onClick={() => navigate(`/post/${post.id}`)}
+        >
             <p className="font-bold">{post.editor}님</p>
             <p>{post.title}</p>
             <p>{post.text}</p>
             <p className="text-sm text-gray-500">{new Date(post.updated).toISOString().split("T")[0]}</p>
-
+            <p className="text-sm text-blue-500">댓글 {post.commentCount || 0}개</p>
+            
             {post.field && Array.isArray(post.field) ? (
                 <div>
                     {isMobile ? (

--- a/src/pages/PostList.jsx
+++ b/src/pages/PostList.jsx
@@ -17,7 +17,7 @@ const PostList = ({
     const [searchQuery, setSearchQuery] = useState("");
     const [filterOption, setFilterOption] = useState("all");
     const [filteredPosts, setFilteredPosts] = useState([...postData]);
-    
+
     // 🔹 컴포넌트가 마운트되거나 postData가 변경될 때 기본 필터 적용
     useEffect(() => {
         if (isDataLoaded) {


### PR DESCRIPTION
learn/PostDetail

## 기타 내용
**PostContent.jsx**
- 해당 컴포넌트는 게시물 내용과 이미지 렌더링을 담당합니다.
- 기존 게시물의 내용과 이미지를 렌더링하는 PostItem.jsx와 상세페이지를 담당하는 PostDetail.jsx의 코드가 중복되어서 재사용할 수 있는 PostContent.jsx컴포넌트 생성

## 코드 관련
1. **React Router의 `useParams()`와 `useNavigate()` 사용법**
    - `useParams()`를 사용하여 URL에서 `id` 값을 가져와 특정 게시물을 조회함.
    - `useNavigate()`를 사용하여 게시물 삭제 후 자동으로 목록 페이지로 이동하도록 설정함.
2. **`fetchPost()`를 `useEffect()`에서 호출하여 최신 데이터 유지**
    - 기존에 `fetchPosts()`를 실행하고 `fetchPost()`를 다시 불러오지 않아 데이터가 동기화되지 않던 문제를 해결.
    - 페이지가 로드될 때마다 최신 데이터를 가져올 수 있도록 보장됨.
    
    ```tsx
    useEffect(() => {
        fetchPost();
        fetchComments();
    }, []);
    ```
    
3. **`handleDelete()`에서 `fetchPosts()` 호출하여 목록 업데이트**
    - 삭제된 게시물이 목록에서 즉시 사라지도록
    
    ```tsx
    
    const handleDelete = async (post) => {
        if (post.editor !== user.name) {
            alert("삭제할 권한이 없습니다.");
            return;
        }
        if (!window.confirm("정말 삭제하시겠습니까?")) return;
    
        try {
            await pb.collection("post").delete(post.id);
            fetchPosts(); // ✅ 삭제 후 목록 업데이트
            navigate(-1); // ✅ 삭제 후 목록 페이지로 이동
        } catch (error) {
            console.error("게시물 삭제 실패:", error);
        }
    };
    
    ```
    
4. **게시물 수정 모달에서 `fetchPosts()` 실행하여 즉시 반영**
    - 게시물 수정 후 새로고침 없이 최신 상태 반영 가능
    
    ```jsx
    {editModal && editPost && (
        <PostEditModal 
            onClick={(e) => e.stopPropagation()}
            editPost={editPost} 
            setEditPost={setEditPost} 
            setEditModal={setEditModal} 
            fetchPosts={fetchPosts} // ✅ 수정 후 목록 자동 반영
        />
    )}
    ```

## 문제점 및 해결

<p>PostDetail에서 PostItem에 있는 게시물 삭제 함수(handleDelete), 게시물 수정 모달 여는 함수(handleEdit)를 가져오려 했으나 실패.</p>

<ol>
<li>
<p><strong><code>navigate()</code>의 <code>state</code>로 <code>handleDelete</code>, <code>handleEdit</code>을 전달하려 했던 문제</strong></p>
<p>❌ <strong>잘못된 코드 예시 (이렇게 하면 안됨)</strong></p>
<pre><code class="language-tsx">onClick={() =&gt; navigate(`/post/${post.id}`, {
    state: { handleDelete, handleEdit }
})}
</code></pre>
<p>📌 <strong>이 방식이 잘못된 이유</strong></p>
<ol>
<li><strong>React Router의 <code>navigate()</code>는 함수(클로저)를 <code>state</code>로 직렬화할 수 없음.</strong>
<ul>
<li><code>state</code>는 JSON 형식으로 저장되므로, <code>handleDelete</code>와 <code>handleEdit</code> 같은 함수는 전달되지 않음.</li>
<li>대신 <code>undefined</code>로 변환되거나 에러가 발생할 수 있음.</li>
</ul>
</li>
<li><strong><code>state</code>로 전달된 값은 React가 관리하는 상태가 아님.</strong>
<ul>
<li><code>PostDetail.jsx</code>에서 <code>useLocation().state</code>로 <code>handleDelete</code>와 <code>handleEdit</code>을 가져오려고 했지만,
해당 값이 <code>undefined</code> 또는 <code>null</code>이 됨.</li>
</ul>
</li>
</ol>
</li>
<li>
<p><strong><code>PostItem.jsx</code>에서 <code>handleDelete</code>, <code>handleEdit</code>을 직접 넘기려고 했던 문제</strong></p>
<ul>
<li>
<p><strong>React Router의 <code>Route</code>를 통해 렌더링되는 컴포넌트는 <code>props</code>를 직접 받을 수 없음.</strong></p>
<pre><code class="language-tsx">&lt;Route path=&quot;/post/:id&quot; element={&lt;PostDetail /&gt;} /&gt;
</code></pre>
<ul>
<li><code>PostDetail</code>은 <code>Route</code>를 통해 렌더링되므로, <code>props</code>를 직접 받을 수 없음.</li>
<li>따라서 <code>PostItem.jsx</code>에서 <code>handleDelete</code>와 <code>handleEdit</code>을 <code>props</code>로 넘기려 해도 <strong><code>PostDetail.jsx</code>에서는 접근할 수 없음.</strong></li>
</ul>
</li>
<li>
<p><strong>React Router는 <code>state</code>를 통해 데이터 전달이 가능하지만, 함수는 직렬화되지 않음.</strong></p>
<ul>
<li><code>navigate()</code>의 <code>state</code>로 함수를 전달하려 했지만, JSON 변환 과정에서 함수가 사라짐.</li>
<li><code>state</code>를 이용한 데이터 전달은 원시 데이터(<code>string</code>, <code>number</code>, <code>object</code>)에 적합하며, 함수는 포함되지 않음.</li>
</ul>
</li>
</ul>
<p>✅ <strong>해결 방법: <code>PostDetail.jsx</code>에서 직접 <code>handleDelete</code>, <code>handleEdit</code> 정의</strong></p>
<p>🔹 올바른 방식은 <code>PostDetail.jsx</code>에서 <code>handleDelete</code>와 <code>handleEdit</code>을 직접 정의하는 것!</p>
<p>🔹 부모에서 받는 것이 아니라, <code>PostDetail.jsx</code>가 자신의 상태를 관리하도록 수정해야 함.</p>
</li>
<li>
<p><strong>부모(<code>Post.jsx</code>)에서 <code>fetchPosts()</code>를 가져오려 했던 문제</strong></p>
<p><code>fetchPosts()</code>도 부모(<code>Post.jsx</code>)에서 <code>PostDetail.jsx</code>로 전달하려고 했을 때, 같은 문제에 부딪혔음.</p>
<ul>
<li><strong>이유:</strong> <code>fetchPosts()</code>는 <code>Post.jsx</code>에서 정의된 상태 기반 함수이며, React Router를 통해 <code>PostDetail.jsx</code>에 전달할 수 없음.</li>
</ul>
<p>✅ <strong>해결 방법: <code>PostDetail.jsx</code>에서 <code>fetchPosts()</code>를 직접 정의</strong></p>
</li>
</ol>
<h3>✅ <strong>최종 해결</strong></h3>

문제 | 해결 방법
-- | --
navigate()의 state로 handleDelete, handleEdit을 전달하려다 실패 | React Router는 함수(클로저)를 직렬화할 수 없음 → PostDetail.jsx에서 직접 정의해야 함
PostItem.jsx에서 handleDelete, handleEdit을 props로 전달하려다 실패 | PostDetail.jsx는 Route를 통해 렌더링되므로 props를 받을 수 없음 → PostDetail.jsx 내부에서 상태 관리
fetchPosts()를 부모(Post.jsx)에서 가져오려다 실패 | PostDetail.jsx에서 fetchPosts()를 직접 정의하여 리렌더링 가능하도록 변경


<!-- notionvc: 7ff3f7f2-ed7e-4aa4-9936-25b366fc7a7e -->