### PR TITLE
게시물 작성 단계별 폼 UI 및 임시 저장 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
       "dependencies": {
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.15",
+        "framer-motion": "^12.5.0",
         "p": "^0.2.0",
         "pocketbase": "^0.24.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-icons": "^5.4.0",
-        "react-router-dom": "^7.1.1",
+        "react-router-dom": "^7.4.0",
         "swiper": "^11.2.4",
         "vite-plugin-windicss": "^1.9.4"
       },
@@ -7301,6 +7302,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.5.0.tgz",
+      "integrity": "sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.5.0",
+        "motion-utils": "^12.5.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -10112,6 +10140,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.5.0.tgz",
+      "integrity": "sha512-uH2PETDh7m+Hjd1UQQ56yHqwn83SAwNjimNPE/kC+Kds0t4Yh7+29rfo5wezVFpPOv57U4IuWved5d1x0kNhbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.5.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.5.0.tgz",
+      "integrity": "sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11418,9 +11461,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
-      "integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.4.0.tgz",
+      "integrity": "sha512-Y2g5ObjkvX3VFeVt+0CIPuYd9PpgqCslG7ASSIdN73LwA1nNWzcMLaoMRJfP3prZFI92svxFwbn7XkLJ+UPQ6A==",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
@@ -11442,12 +11485,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.1.tgz",
-      "integrity": "sha512-vSrQHWlJ5DCfyrhgo0k6zViOe9ToK8uT5XGSmnuC2R3/g261IdIMpZVqfjD6vWSXdnf5Czs4VA/V60oVR6/jnA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.4.0.tgz",
+      "integrity": "sha512-VlksBPf3n2bijPvnA7nkTsXxMAKOj+bWp4R9c3i+bnwlSOFAGOkJkKhzy/OsRkWaBMICqcAl1JDzh9ZSOze9CA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.1.1"
+        "react-router": "7.4.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -12889,7 +12932,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
+    "framer-motion": "^12.5.0",
     "p": "^0.2.0",
     "pocketbase": "^0.24.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
-    "react-router-dom": "^7.1.1",
+    "react-router-dom": "^7.4.0",
     "swiper": "^11.2.4",
     "vite-plugin-windicss": "^1.9.4"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import FavoriteFiles from "./pages/FavoriteFiles";
 import Post from "./pages/Post";
 import PostDetail from "./pages/PostDetail";
 import { UserProvider } from "./context/UserContext"; // ✅ UserContext 추가
+import StepPostPage from "./pages/StepPostPage";
 
 function App() {
     const [isLoading, setIsLoading] = useState(false); // 로딩 상태 관리
@@ -118,6 +119,7 @@ function App() {
                             element={<Post isLoggedIn={isLoggedIn}  loggedInUserId={loggedInUserId} isLoading={isLoading} setIsLoading={setIsLoading}/>}
                         />
                         <Route path="/post/:id" element={<PostDetail />} />
+                        <Route path="/post/create" element={<StepPostPage />} />
                     </Route>
                 </Routes>
             </Router>

--- a/src/lib/getPbImageURL.js
+++ b/src/lib/getPbImageURL.js
@@ -1,4 +1,4 @@
 // 이미지 관련
-export default function getPbImageURL(item,fileName = 'field'){
-    return `${import.meta.env.VITE_PB_API}/files/${item.collectionId}/${item.id}/${item.field}`
+export default function getPbImageURL(item,fileName = 'images'){
+    return `${import.meta.env.VITE_PB_API}/files/${item.collectionId}/${item.id}/${item.images}`
   }

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -44,9 +44,14 @@ const Post = () => {
         <section className="flex flex-col items-center">
             <div className="flex justify-between w-full max-w-2xl">
                 <h1 className="text-2xl pb-4">게시판</h1>
-                <button onClick={() => setShowForm(true)} className="px-4 py-2 bg-blue-500 text-white rounded">
-                    작성하기
-                </button>
+                <div className="flex justify-between gap-1">
+                    <button onClick={() => setShowForm(true)} className="px-4 py-2 bg-blue-500 hover:bg-blue-700 text-white rounded">
+                        팝업으로 작성하기
+                    </button>
+                    <button className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded">
+                        Step으로 작성하기
+                    </button>
+                </div>
             </div>
 
             <PostList 

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -3,8 +3,10 @@ import pb from "../lib/pocketbase";
 import PostList from "./PostList";
 import PostModal from "./PostModal";
 import { useUser } from "../context/UserContext"; // ✅ Context에서 `user` 가져오기
+import { useNavigate } from "react-router-dom";
 
 const Post = () => {
+    const navigate = useNavigate();
     const user = useUser(); // ✅ 부모(`UserProvider`)에서 `user` 받아오기
     const [postData, setPostData] = useState([]);
     const [editPost, setEditPost] = useState(null);
@@ -45,10 +47,16 @@ const Post = () => {
             <div className="flex justify-between w-full max-w-2xl">
                 <h1 className="text-2xl pb-4">게시판</h1>
                 <div className="flex justify-between gap-1">
-                    <button onClick={() => setShowForm(true)} className="px-4 py-2 bg-blue-500 hover:bg-blue-700 text-white rounded">
+                    <button 
+                        onClick={() => setShowForm(true)} 
+                        className="px-4 py-2 bg-blue-500 hover:bg-blue-700 text-white rounded"
+                    >
                         팝업으로 작성하기
                     </button>
-                    <button className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded">
+                    <button 
+                        onClick={() => navigate("/post/create")} 
+                        className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded"
+                    >
                         Step으로 작성하기
                     </button>
                 </div>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -11,18 +11,18 @@ const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMo
             <div className="mb-2">
                 <p className="font-bold text-gray-700 mb-2">{post.editor}님</p>
                 <h2 className="text-xl font-bold">{post.title}</h2>
-                <p className="text-gray-700 mb-2">{post.text}</p>
+                <p className="text-gray-700 mb-2">{post.description}</p>
                 <p className="text-sm text-gray-500">
                     {new Date(post.updated).toISOString().split("T")[0]}
                 </p>
             </div>
 
             {/* 이미지 슬라이더 */}
-            {post.field && Array.isArray(post.field) ? (
+            {post.images && Array.isArray(post.images) ? (
                 <div onClick={onClick}>
                     {isMobile ? (
                         <Swiper navigation modules={[Navigation]}>
-                            {post.field.map((img, index) => (
+                            {post.images.map((img, index) => (
                                 <SwiperSlide key={index}>
                                     <img 
                                         src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
@@ -35,7 +35,7 @@ const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMo
                         </Swiper>
                     ) : (
                         <div className="flex space-x-2">
-                            {post.field.map((img, index) => (
+                            {post.images.map((img, index) => (
                                 <img
                                     key={index}
                                     src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`}

--- a/src/pages/PostEditModal.jsx
+++ b/src/pages/PostEditModal.jsx
@@ -6,7 +6,7 @@ import PostImageModal from "./PostImageModal";
 const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPosts }) => {
     const fileInputRef = useRef(null);
     const [title, setTitle] = useState(editPost.title);
-    const [text, setText] = useState(editPost.text);
+    const [description, setDescription] = useState(editPost.description);
     const [postImgs, setPostImgs] = useState([]);
     const [previewImgs, setPreviewImgs] = useState([]);
     const [uploading, setUploading] = useState(false);
@@ -15,13 +15,13 @@ const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPost
     // 🔹 파일 업로드 핸들러
     const uploadFiles = (e) => {
         const files = Array.from(e.target.files);
-        if ((editPost?.field?.length || 0) + postImgs.length + files.length > 3) {
+        if ((editPost?.images?.length || 0) + postImgs.length + files.length > 3) {
             alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
             return;
         }
         const newPreviewImgs = files.map(file => URL.createObjectURL(file));
-        setPostImgs(prev => [...prev, ...files].slice(0, 3 - (editPost?.field?.length || 0)));
-        setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3 - (editPost?.field?.length || 0)));
+        setPostImgs(prev => [...prev, ...files].slice(0, 3 - (editPost?.images?.length || 0)));
+        setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3 - (editPost?.images?.length || 0)));
 
         // ✅ 파일 선택 후 `input` 값 초기화
         if (fileInputRef.current) {
@@ -44,12 +44,12 @@ const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPost
 
     // 🔹 기존 이미지 삭제 핸들러
     const removeExistingImage = (index) => {
-        if (editPost.field.length <= 1) {
+        if (editPost.images.length <= 1) {
             alert("최소 1개의 이미지는 있어야 합니다.");
             return;
         }
-        const updatedImages = editPost.field.filter((_, i) => i !== index);
-        setEditPost({ ...editPost, field: updatedImages });
+        const updatedImages = editPost.images.filter((_, i) => i !== index);
+        setEditPost({ ...editPost, images: updatedImages });
     };
 
     // 🔹 게시물 수정 핸들러
@@ -59,18 +59,19 @@ const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPost
         try {
             const formData = new FormData();
             formData.append("title", title);
-            formData.append("text", text);
+            formData.append("description", description);
 
             // ✅ 기존 이미지 추가
-            if (editPost.field) {
-                editPost.field.forEach((img) => formData.append("field", img));
+            if (editPost.images) {
+                editPost.images.forEach((img) => formData.append("images", img));
             }
 
             // ✅ 새로운 이미지 추가
-            postImgs.forEach((img) => formData.append("field", img));
+            postImgs.forEach((img) => formData.append("images", img));
 
             await pb.collection("post").update(editPost.id, formData);
 
+            console.log("수정 완료되었습니다!");
             fetchPosts();
             setEditModal(false);
         } catch (error) {
@@ -96,8 +97,8 @@ const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPost
                         className="w-full p-2 border rounded"
                     />
                     <textarea 
-                        value={text} 
-                        onChange={(e) => setText(e.target.value)} 
+                        value={description} 
+                        onChange={(e) => setDescription(e.target.value)} 
                         placeholder="내용 입력" 
                         className="w-full p-2 border rounded mt-2"
                     />
@@ -121,7 +122,7 @@ const PostEditModal = ({ onClick, editPost, setEditPost, setEditModal, fetchPost
 
                     {/* ✅ 기존 이미지 미리보기 */}
                     <div className="mt-2 flex space-x-2">
-                        {editPost?.field?.map((img, index) => (
+                        {editPost?.images?.map((img, index) => (
                             <div key={index} className="relative">
                                 <img
                                     src={`${import.meta.env.VITE_PB_API}/files/${editPost.collectionId}/${editPost.id}/${img}`} 

--- a/src/pages/PostModal.jsx
+++ b/src/pages/PostModal.jsx
@@ -8,7 +8,7 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
     const user = useUser(); // ✅ 부모(`UserProvider`)에서 `user` 받아오기
     const fileInputRef = useRef(null);
     const [title, setTitle] = useState(post ? post.title : "");
-    const [text, setText] = useState(post ? post.text : "");
+    const [description, setDescription] = useState(post ? post.description : "");
     const [postImgs, setPostImgs] = useState([]);
     const [previewImgs, setPreviewImgs] = useState([]);
     const [uploading, setUploading] = useState(false);
@@ -17,7 +17,7 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
 
     const uploadFiles = (e) => {
         const files = Array.from(e.target.files);
-        if ((post?.field?.length || 0) + postImgs.length + files.length > 3) {
+        if ((post?.images?.length || 0) + postImgs.length + files.length > 3) {
             alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
             return;
         }
@@ -33,7 +33,7 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        if (!title || !text || postImgs.length === 0 || !user) {
+        if (!title || !description || postImgs.length === 0 || !user) {
             alert("제목, 내용, 이미지를 모두 입력해주세요.");
             return;
         }
@@ -41,12 +41,12 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
         try {
             const formData = new FormData();
             formData.append("title", title);
-            formData.append("text", text);
+            formData.append("description", description);
             formData.append("editor", user.name);
             formData.append("user", user.id);
             formData.append("updated", new Date().toISOString().split("T")[0]);
 
-            postImgs.forEach((img) => formData.append("field", img));
+            postImgs.forEach((img) => formData.append("images", img));
 
             if (post) {
                 await pb.collection("post").update(post.id, formData);
@@ -76,8 +76,8 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
                         className="w-full p-2 border rounded"
                     />
                     <textarea 
-                        value={text} 
-                        onChange={(e) => setText(e.target.value)} 
+                        value={description} 
+                        onChange={(e) => setDescription(e.target.value)} 
                         placeholder="내용 입력" 
                         className="w-full p-2 border rounded mt-2"
                     />
@@ -120,9 +120,9 @@ const PostModal = ({ post, setShowForm, fetchPosts }) => {
                     <button 
                         type="submit" 
                         className={`mt-4 px-4 py-2 rounded w-full ${
-                            title && text && postImgs.length > 0 ? "bg-green-500 text-white hover:bg-green-600" : "bg-gray-400 text-gray-200 cursor-not-allowed"
+                            title && description && postImgs.length > 0 ? "bg-green-500 text-white hover:bg-green-600" : "bg-gray-400 text-gray-200 cursor-not-allowed"
                         }`} 
-                        disabled={!title || !text || postImgs.length === 0 || uploading}
+                        disabled={!title || !description || postImgs.length === 0 || uploading}
                     >
                         {uploading ? "업로드 중..." : "게시하기"}
                     </button>

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -165,7 +165,7 @@ const StepPostPage = ({ post }) => {
               >이어서 작성</button>
               <button
                 onClick={() => {
-                  localStorage.removeItem("stepPostData");
+                  localStorage.removeItem(STORAGE_KEY);
                   setFormData({
                     title: "",
                     category: "",

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -10,6 +10,21 @@ const steps = [
 const StepPostPage = () => {
   const navigate = useNavigate();
   const [step, setStep] = useState(0);
+  const [formData, setFormData] = useState({
+    title: "",
+    category: "",
+    description: "",
+    location: "",
+    date: "",
+    timeStart: "",
+    timeEnd: "",
+    capacity: "",
+    fee: ""
+  });
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
 
   const nextStep = () => setStep((s) => Math.min(s + 1, steps.length - 1));
   const prevStep = () => setStep((s) => Math.max(s - 1, 0));
@@ -26,8 +41,92 @@ const StepPostPage = () => {
           exit={{ opacity: 0, x: -30 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="w-full p-4 border border-dashed rounded text-center text-gray-500">
-            {steps[step]} 입력 영역 (UI 구성 예정)
+          <div className="w-full">
+            {step === 0 && (
+              <input
+                value={formData.title}
+                onChange={(e) => handleChange("title", e.target.value)}
+                placeholder="모임 제목"
+                className="w-full p-2 border rounded"
+              />
+            )}
+            {step === 1 && (
+              <select
+                value={formData.category}
+                onChange={(e) => handleChange("category", e.target.value)}
+                className="w-full p-2 border rounded"
+              >
+                <option value="">요리 종류 선택</option>
+                <option value="양식">양식</option>
+                <option value="중식">중식</option>
+                <option value="일식">일식</option>
+                <option value="베이커리">베이커리</option>
+                <option value="기타">기타</option>
+              </select>
+            )}
+            {step === 2 && (
+              <textarea
+                value={formData.description}
+                onChange={(e) => handleChange("description", e.target.value)}
+                placeholder="모임 소개"
+                className="w-full p-2 border rounded"
+              />
+            )}
+            {step === 3 && (
+              <input
+                value={formData.location}
+                onChange={(e) => handleChange("location", e.target.value)}
+                placeholder="모임 위치"
+                className="w-full p-2 border rounded"
+              />
+            )}
+            {step === 4 && (
+              <div className="space-y-2">
+                <input
+                  type="date"
+                  value={formData.date}
+                  onChange={(e) => handleChange("date", e.target.value)}
+                  className="w-full p-2 border rounded"
+                />
+                <div className="flex gap-2">
+                  <input
+                    type="time"
+                    value={formData.timeStart}
+                    onChange={(e) => handleChange("timeStart", e.target.value)}
+                    className="w-full p-2 border rounded"
+                  />
+                  <input
+                    type="time"
+                    value={formData.timeEnd}
+                    onChange={(e) => handleChange("timeEnd", e.target.value)}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            )}
+            {step === 5 && (
+              <input
+                type="number"
+                value={formData.capacity}
+                onChange={(e) => handleChange("capacity", e.target.value)}
+                placeholder="모임 인원"
+                className="w-full p-2 border rounded"
+              />
+            )}
+            {step === 6 && (
+              <input
+                type="text"
+                value={formData.fee}
+                onChange={(e) => handleChange("fee", e.target.value)}
+                placeholder="참가비 (예: 30000원)"
+                className="w-full p-2 border rounded"
+              />
+            )}
+            {step > 6 && (
+              <div className="text-center text-gray-500 p-4 border border-dashed rounded">
+                {steps[step]} 입력 영역 (UI 구성 예정)
+              </div>
+            )}
           </div>
         </motion.div>
       </AnimatePresence>

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -10,7 +10,6 @@ const steps = [
     "title", "category", "description", "location", "date", "capacity", "fee", "images", "preview"
 ];
 
-
 const StepPostPage = ({ post }) => {
     const user = useUser();
     const STORAGE_KEY = `stepPostData_${user.id}`;
@@ -192,7 +191,10 @@ const StepPostPage = ({ post }) => {
 
     return (
         <div className="max-w-xl mx-auto p-6">
-            <h2 className="text-lg font-bold mb-4">게시물 작성</h2>
+            <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-bold ">게시물 작성</h2>
+                <button className="text-sm text-gray-500 hover:text-gray-800">임시저장</button>
+            </div>
 
             <AnimatePresence mode="wait">
                 <motion.div

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -60,17 +60,32 @@ const StepPostPage = ({ post }) => {
         alert("임시 저장되었습니다.");
     };
 
-    // 페이지 이탈 감지 및 저장 여부 확인
+    // 페이지 이탈 감지 및 저장 여부 확인 조건
     useEffect(() => {
+        const isFormTouched = () => {
+            return (
+                formData.title.trim() !== "" ||
+                formData.description.trim() !== "" ||
+                formData.category.length > 0 ||
+                formData.location.trim() !== "" ||
+                formData.date !== "" ||
+                formData.timeStart !== "" ||
+                formData.timeEnd !== "" ||
+                formData.capacity.trim() !== "" ||
+                formData.fee.trim() !== "" ||
+                previewImgs.length > 0
+            );
+        };
+    
         const handleBeforeUnload = (e) => {
-            if (!isManualSave && formData.title.trim() !== "") {
+            if (!isManualSave && isFormTouched()) {
                 e.preventDefault();
                 e.returnValue = "";
             }
         };
-
-        const handleRouteChange = (e) => {
-            if (!isManualSave && formData.title.trim() !== "") {
+    
+        const handleRouteChange = () => {
+            if (!isManualSave && isFormTouched()) {
                 const confirmLeave = window.confirm("임시 저장 하시겠습니까?");
                 if (confirmLeave) handleManualSave();
                 else localStorage.removeItem(STORAGE_KEY);

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -1,0 +1,49 @@
+// StepPostPage.jsx
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "framer-motion";
+
+const steps = [
+  "title", "category", "description", "location", "date", "capacity", "fee", "images", "preview"
+];
+
+const StepPostPage = () => {
+  const navigate = useNavigate();
+  const [step, setStep] = useState(0);
+
+  const nextStep = () => setStep((s) => Math.min(s + 1, steps.length - 1));
+  const prevStep = () => setStep((s) => Math.max(s - 1, 0));
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h2 className="text-lg font-bold mb-4">게시물 작성</h2>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, x: 30 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -30 }}
+          transition={{ duration: 0.3 }}
+        >
+          <div className="w-full p-4 border border-dashed rounded text-center text-gray-500">
+            {steps[step]} 입력 영역 (UI 구성 예정)
+          </div>
+        </motion.div>
+      </AnimatePresence>
+
+      <div className="flex justify-between gap-1 mt-6">
+        {step > 0 && (
+          <button onClick={prevStep} className="px-4 py-2 break-keep hover:text-gray-600">이전</button>
+        )}
+        {step < steps.length - 1 ? (
+          <button onClick={nextStep} className="px-4 py-2 w-full bg-blue-500 hover:bg-blue-700 text-white rounded break-keep">다음 {step + 1}/{steps.length}</button>
+        ) : (
+          <button onClick={() => navigate("/post")} className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded break-keep">완료 후 이동</button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StepPostPage;

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -1,148 +1,233 @@
 // StepPostPage.jsx
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
+import PostImageModal from "./PostImageModal";
+import useImageViewer from "../hooks/useImageViewer";
 
 const steps = [
   "title", "category", "description", "location", "date", "capacity", "fee", "images", "preview"
 ];
 
-const StepPostPage = () => {
-  const navigate = useNavigate();
-  const [step, setStep] = useState(0);
-  const [formData, setFormData] = useState({
-    title: "",
-    category: "",
-    description: "",
-    location: "",
-    date: "",
-    timeStart: "",
-    timeEnd: "",
-    capacity: "",
-    fee: ""
-  });
+const StepPostPage = ({ post }) => {
+    const navigate = useNavigate();
+    const [step, setStep] = useState(0);
+    const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer();
+    const [formData, setFormData] = useState({
+        title: "",
+        category: "",
+        description: "",
+        location: "",
+        date: "",
+        timeStart: "",
+        timeEnd: "",
+        capacity: "",
+        fee: "",
+        images: []
+    });
+    const fileInputRef = useRef(null);
+    const [postImgs, setPostImgs] = useState([]);
+    const [previewImgs, setPreviewImgs] = useState([]);
 
-  const handleChange = (field, value) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-  };
+    const handleChange = (field, value) => {
+        setFormData((prev) => ({ ...prev, [field]: value }));
+    };
 
-  const nextStep = () => setStep((s) => Math.min(s + 1, steps.length - 1));
-  const prevStep = () => setStep((s) => Math.max(s - 1, 0));
+    const uploadFiles = (e) => {
+        const files = Array.from(e.target.files);
+        if ((post?.field?.length || 0) + postImgs.length + files.length > 3) {
+            alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
+            return;
+        }
+        const newPreviewImgs = files.map(file => URL.createObjectURL(file));
+        setPostImgs(prev => [...prev, ...files].slice(0, 3));
+        setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3));
+    };
 
-  return (
-    <div className="max-w-xl mx-auto p-6">
-      <h2 className="text-lg font-bold mb-4">게시물 작성</h2>
+    const removePreviewImage = (index) => {
+        setPreviewImgs(prev => prev.filter((_, i) => i !== index));
+        setPostImgs(prev => prev.filter((_, i) => i !== index));
+    };
 
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={step}
-          initial={{ opacity: 0, x: 30 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -30 }}
-          transition={{ duration: 0.3 }}
-        >
-          <div className="w-full">
-            {step === 0 && (
-              <input
-                value={formData.title}
-                onChange={(e) => handleChange("title", e.target.value)}
-                placeholder="모임 제목"
-                className="w-full p-2 border rounded"
-              />
-            )}
-            {step === 1 && (
-              <select
-                value={formData.category}
-                onChange={(e) => handleChange("category", e.target.value)}
-                className="w-full p-2 border rounded"
-              >
-                <option value="">요리 종류 선택</option>
-                <option value="양식">양식</option>
-                <option value="중식">중식</option>
-                <option value="일식">일식</option>
-                <option value="베이커리">베이커리</option>
-                <option value="기타">기타</option>
-              </select>
-            )}
-            {step === 2 && (
-              <textarea
-                value={formData.description}
-                onChange={(e) => handleChange("description", e.target.value)}
-                placeholder="모임 소개"
-                className="w-full p-2 border rounded"
-              />
-            )}
-            {step === 3 && (
-              <input
-                value={formData.location}
-                onChange={(e) => handleChange("location", e.target.value)}
-                placeholder="모임 위치"
-                className="w-full p-2 border rounded"
-              />
-            )}
-            {step === 4 && (
-              <div className="space-y-2">
-                <input
-                  type="date"
-                  value={formData.date}
-                  onChange={(e) => handleChange("date", e.target.value)}
-                  className="w-full p-2 border rounded"
-                />
-                <div className="flex gap-2">
-                  <input
-                    type="time"
-                    value={formData.timeStart}
-                    onChange={(e) => handleChange("timeStart", e.target.value)}
-                    className="w-full p-2 border rounded"
-                  />
-                  <input
-                    type="time"
-                    value={formData.timeEnd}
-                    onChange={(e) => handleChange("timeEnd", e.target.value)}
-                    className="w-full p-2 border rounded"
-                  />
+    const nextStep = () => setStep((s) => Math.min(s + 1, steps.length - 1));
+    const prevStep = () => setStep((s) => Math.max(s - 1, 0));
+
+    return (
+        <div className="max-w-xl mx-auto p-6">
+            <h2 className="text-lg font-bold mb-4">게시물 작성</h2>
+
+            <AnimatePresence mode="wait">
+                <motion.div
+                key={step}
+                initial={{ opacity: 0, x: 30 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -30 }}
+                transition={{ duration: 0.3 }}
+                >
+                <div className="w-full">
+                    {step === 0 && (
+                    <input
+                        value={formData.title}
+                        onChange={(e) => handleChange("title", e.target.value)}
+                        placeholder="모임 제목"
+                        className="w-full p-2 border rounded"
+                    />
+                    )}
+                    {step === 1 && (
+                    <select
+                        value={formData.category}
+                        onChange={(e) => handleChange("category", e.target.value)}
+                        className="w-full p-2 border rounded"
+                    >
+                        <option value="">요리 종류 선택</option>
+                        <option value="양식">양식</option>
+                        <option value="중식">중식</option>
+                        <option value="일식">일식</option>
+                        <option value="베이커리">베이커리</option>
+                        <option value="기타">기타</option>
+                    </select>
+                    )}
+                    {step === 2 && (
+                    <textarea
+                        value={formData.description}
+                        onChange={(e) => handleChange("description", e.target.value)}
+                        placeholder="모임 소개"
+                        className="w-full p-2 border rounded"
+                    />
+                    )}
+                    {step === 3 && (
+                    <input
+                        value={formData.location}
+                        onChange={(e) => handleChange("location", e.target.value)}
+                        placeholder="모임 위치"
+                        className="w-full p-2 border rounded"
+                    />
+                    )}
+                    {step === 4 && (
+                    <div className="space-y-2">
+                        <input
+                        type="date"
+                        value={formData.date}
+                        onChange={(e) => handleChange("date", e.target.value)}
+                        className="w-full p-2 border rounded"
+                        />
+                        <div className="flex gap-2">
+                        <input
+                            type="time"
+                            value={formData.timeStart}
+                            onChange={(e) => handleChange("timeStart", e.target.value)}
+                            className="w-full p-2 border rounded"
+                        />
+                        <input
+                            type="time"
+                            value={formData.timeEnd}
+                            onChange={(e) => handleChange("timeEnd", e.target.value)}
+                            className="w-full p-2 border rounded"
+                        />
+                        </div>
+                    </div>
+                    )}
+                    {step === 5 && (
+                    <input
+                        type="number"
+                        value={formData.capacity}
+                        onChange={(e) => handleChange("capacity", e.target.value)}
+                        placeholder="모임 인원"
+                        className="w-full p-2 border rounded"
+                    />
+                    )}
+                    {step === 6 && (
+                    <input
+                        type="text"
+                        value={formData.fee}
+                        onChange={(e) => handleChange("fee", e.target.value)}
+                        placeholder="참가비 (예: 30000원)"
+                        className="w-full p-2 border rounded"
+                    />
+                    )}
+                    {step === 7 && (
+                    <div>
+                        <input
+                            type="file"
+                            ref={fileInputRef}
+                            onChange={uploadFiles}
+                            className="opacity-0 absolute w-0 h-0" // ✅ 파일 입력 필드 숨김 (하지만 클릭 가능)
+                            multiple 
+                            accept="image/*" 
+                            id="fileUpload"
+                        />
+                        <label 
+                            htmlFor="fileUpload" 
+                            className="px-4 py-2 bg-blue-500 text-white rounded cursor-pointer hover:bg-blue-600 inline-block"
+                        >
+                            파일 선택
+                        </label>
+                        <div className="flex gap-2 mt-2">
+                        {previewImgs.map((img, index) => (
+                            <div key={index} className="relative">
+                                <img 
+                                    src={img} 
+                                    alt="미리보기" 
+                                    onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                    className="w-20 h-20 object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                />
+                                <button
+                                    onClick={() => removePreviewImage(index)} 
+                                    className="absolute top-0 right-0 bg-red-500 text-white rounded-full px-1"
+                                >x</button>
+                            </div>
+                        ))}
+                        </div>
+                    </div>
+                    )}
+
+                    {step === 8 && (
+                    <div className="space-y-2">
+                        <h3 className="text-xl font-bold">미리보기</h3>
+                        <p><strong>제목:</strong> {formData.title}</p>
+                        <p><strong>요리 종류:</strong> {formData.category}</p>
+                        <p><strong>소개:</strong> {formData.description}</p>
+                        <p><strong>위치:</strong> {formData.location}</p>
+                        <p><strong>일정:</strong> {formData.date} / {formData.timeStart} - {formData.timeEnd}</p>
+                        <p><strong>인원:</strong> {formData.capacity}명</p>
+                        <p><strong>참가비:</strong> {formData.fee}</p>
+                        <div className="flex gap-2 mt-2">
+                        {previewImgs.map((img, index) => (
+                            <img 
+                                key={index}
+                                src={img} 
+                                alt="미리보기" 
+                                onClick={() => handleImageClick(img, post, true)} // ✅ 기존 이미지 클릭 시 PostImageModal 실행
+                                className="w-20 h-20 object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                            />
+                        ))}
+                        </div>
+                    </div>
+                    )}
                 </div>
-              </div>
-            )}
-            {step === 5 && (
-              <input
-                type="number"
-                value={formData.capacity}
-                onChange={(e) => handleChange("capacity", e.target.value)}
-                placeholder="모임 인원"
-                className="w-full p-2 border rounded"
-              />
-            )}
-            {step === 6 && (
-              <input
-                type="text"
-                value={formData.fee}
-                onChange={(e) => handleChange("fee", e.target.value)}
-                placeholder="참가비 (예: 30000원)"
-                className="w-full p-2 border rounded"
-              />
-            )}
-            {step > 6 && (
-              <div className="text-center text-gray-500 p-4 border border-dashed rounded">
-                {steps[step]} 입력 영역 (UI 구성 예정)
-              </div>
-            )}
-          </div>
-        </motion.div>
-      </AnimatePresence>
+                </motion.div>
+            </AnimatePresence>
 
-      <div className="flex justify-between gap-1 mt-6">
-        {step > 0 && (
-          <button onClick={prevStep} className="px-4 py-2 break-keep hover:text-gray-600">이전</button>
-        )}
-        {step < steps.length - 1 ? (
-          <button onClick={nextStep} className="px-4 py-2 w-full bg-blue-500 hover:bg-blue-700 text-white rounded break-keep">다음 {step + 1}/{steps.length}</button>
-        ) : (
-          <button onClick={() => navigate("/post")} className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded break-keep">완료 후 이동</button>
-        )}
-      </div>
-    </div>
-  );
+            <div className="flex justify-between gap-1 mt-6">
+                {step > 0 && (
+                <button onClick={prevStep} className="px-4 py-2 break-keep hover:text-gray-600">이전</button>
+                )}
+                {step < steps.length - 1 ? (
+                <button onClick={nextStep} className="px-4 py-2 w-full bg-blue-500 hover:bg-blue-700 text-white rounded break-keep">다음 {step + 1}/{steps.length}</button>
+                ) : (
+                <button onClick={() => navigate("/post")} className="px-4 py-2 bg-orange-500 hover:bg-orange-700 text-white rounded break-keep">완료 후 이동</button>
+                )}
+            </div>
+
+            {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}
+            {selectedImage && (
+                <PostImageModal 
+                    selectedImage={selectedImage} 
+                    setSelectedImage={setSelectedImage} 
+                />
+            )}
+        </div>
+    );
 };
 
 export default StepPostPage;

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -4,14 +4,16 @@ import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import PostImageModal from "./PostImageModal";
 import useImageViewer from "../hooks/useImageViewer";
+import { useUser } from "../context/UserContext"; // 상단에 추가
 
 const steps = [
     "title", "category", "description", "location", "date", "capacity", "fee", "images", "preview"
 ];
 
-const STORAGE_KEY = "stepPostData";
 
 const StepPostPage = ({ post }) => {
+    const user = useUser();
+    const STORAGE_KEY = `stepPostData_${user.id}`;
     const navigate = useNavigate();
     const [step, setStep] = useState(0);
     const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer();
@@ -50,6 +52,7 @@ const StepPostPage = ({ post }) => {
     const [previewImgs, setPreviewImgs] = useState(() => parsed?.previewImgs || []);
     const fileInputRef = useRef(null);
     const [errors, setErrors] = useState({});
+    
 
     useEffect(() => {
         const serializedImages = postImgs.map(file => file.name);


### PR DESCRIPTION
## 📌 PR 제목
feat: 게시물 작성 단계별 폼 UI 및 임시 저장 기능 구현
branch: `learn/StepByStep`

---

## 📄 변경 내용
- `StepPostPage` 컴포넌트 구현: 게시물 작성을 단계별로 진행할 수 있는 UI 구성  
- 총 9단계: `제목`, `카테고리`, `소개`, `위치`, `일정`, `모집 인원`, `참가비`, `이미지`, `미리보기`
- 각 단계별 유효성 검사 및 에러 메시지 제공
- 이미지 최대 3장 업로드 제한
- `localStorage` 기반 임시 저장 및 이어서 작성 기능 구현
- 페이지 이탈 시 임시 저장 유도 (beforeunload + popstate 감지)
- 프리뷰 단계에서 전체 정보 확인 가능
- 작성 완료 시 `/post` 경로로 이동

---

## 💾 주요 기능
- `임시 저장` 버튼 클릭 시 현재 입력된 정보 `localStorage`에 저장
- 임시 저장된 내용이 있는 경우, 이어서 작성할지 새로 작성할지 선택 가능
- 이미지 미리보기 클릭 시 `PostImageModal`로 확대 보기 가능
- **임시 저장 유도 조건 개선**  
  → 기존에는 `title` 입력 여부만 판단했으나,  
  이제는 `description`, `category`, `location`, `date`, `이미지` 등 주요 입력값 중 하나라도 입력된 경우 저장 유도됨  
  → 예외적 흐름이나 향후 확장에 대비해 유연한 조건으로 개선

---

## 🧪 테스트 사항
- [x] 단계별 폼 전환 및 데이터 유지 확인
- [x] 유효성 검사 후 다음 단계 이동 확인
- [x] 임시 저장/삭제/불러오기 로직 정상 동작 확인
- [x] 이미지 업로드 3개 제한 적용 여부
- [x] 미리보기 내용과 입력값 일치 여부
- [x] title 외의 필드만 입력해도 이탈 시 저장 유도되는지 확인

---

## 🔧 향후 작업 예정
- [ ] 라우터이동 시 임시저장여부 팝업창 안뜨는 오류
- [ ] 유효성 검사 조건 UI 메세지 수정
- [ ] 이미지 리사이징 & 이미지 압축