### PR TITLE
이미지 압축

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.15",
+        "browser-image-compression": "^2.0.2",
         "framer-motion": "^12.5.0",
         "p": "^0.2.0",
         "pocketbase": "^0.24.0",
@@ -5566,6 +5567,15 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.24.3",
@@ -13725,6 +13735,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
+    "browser-image-compression": "^2.0.2",
     "framer-motion": "^12.5.0",
     "p": "^0.2.0",
     "pocketbase": "^0.24.0",

--- a/src/hooks/useImageCompressor.js
+++ b/src/hooks/useImageCompressor.js
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import imageCompression from "browser-image-compression";
+
+const useImageCompressor = () => {
+  const compressImages = useCallback(async (files, options = {}) => {
+    const defaultOptions = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 1024,
+      useWebWorker: true,
+    };
+
+    const compressionOptions = { ...defaultOptions, ...options };
+
+    try {
+      const compressedFiles = await Promise.all(
+        files.map(async (file) => {
+          console.log("압축 전:", (file.size / 1024).toFixed(2), "KB");
+          const compressed = await imageCompression(file, compressionOptions);
+          console.log("압축 후:", (compressed.size / 1024).toFixed(2), "KB");
+          return compressed;
+        })
+      );
+      return compressedFiles;
+    } catch (error) {
+      console.error("이미지 압축 실패:", error);
+      throw error;
+    }
+  }, []);
+
+  return { compressImages };
+};
+
+export default useImageCompressor;


### PR DESCRIPTION
branch : learn/ImageCompression

✅ 의존성 추가
```
npm i browser-image-compression
```

📌 주요 포인트
- maxSizeMB: 1: 1MB 이하로 압축
- maxWidthOrHeight: 1024: 최대 너비/높이 제한
- 커스텀 훅 useImageCompressor (src/hooks/useImageCompressor.js)

🎯 기대 효과
- 로직 분리로 코드 가독성 개선
- 재사용 가능한 훅으로 유지보수 효율 상승
- 압축 로직을 다른 페이지/컴포넌트에도 쉽게 도입 가능