### PR TITLE
마이페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Post from "./pages/Post";
 import PostDetail from "./pages/PostDetail";
 import { UserProvider } from "./context/UserContext"; // ✅ UserContext 추가
 import StepPostPage from "./pages/StepPostPage";
+import MyPage from './pages/MyPage';
 
 function App() {
     const [isLoading, setIsLoading] = useState(false); // 로딩 상태 관리
@@ -120,6 +121,7 @@ function App() {
                         />
                         <Route path="/post/:id" element={<PostDetail />} />
                         <Route path="/post/create" element={<StepPostPage />} />
+                        <Route path="/mypage/:userId" element={<MyPage />} />
                     </Route>
                 </Routes>
             </Router>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -80,11 +80,19 @@ const Header = ({ isLoggedIn, isDarkMode, setDarkMode, isLoading, setIsLoading }
                         </li>
                     </>
                 )}
+
                 {isLoggedIn && user && (
-                    <li>
-                        <p className="whitespace-nowrap">{user.name}님</p>
-                    </li>
+                    <>
+                        <Link to={`/mypage/${user.id}`} className="hover:underline">
+                            마이페이지
+                        </Link>
+
+                        <li>
+                            <p className="whitespace-nowrap text-gray-500">{user.name}님</p>
+                        </li>
+                    </>
                 )}
+
                 <li className="flex gap-2">
                     <Button
                         type= 'darkMode'

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const MyPage = () => {
+  return (
+    <div>MyPage</div>
+  )
+}
+
+export default MyPage

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,24 +1,43 @@
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import pb from "../lib/pocketbase";
 
 const MyPage = () => {
     const { userId } = useParams();
+    const navigate = useNavigate();
     const [profile, setProfile] = useState(null);
     const [editing, setEditing] = useState(false);
     const [avatar, setAvatar] = useState(null);
+    const [nickname, setNickname] = useState(""); // ✅ nickname 추가
+    const [userPosts, setUserPosts] = useState([]); // ✅ 내가 작성한 게시글 상태 추가
 
     useEffect(() => {
         const fetchUser = async () => {
             try {
-                const data = await pb.collection("users").getOne(userId); // ✅ 이걸 기준으로 가져와야 함
+                const data = await pb.collection("users").getOne(userId);
                 setProfile(data);
+                setNickname(data.name); // name 기반 nickname 기본값
             } catch (err) {
                 console.error("유저 정보 불러오기 실패:", err);
             }
         };
 
-        if (userId) fetchUser();
+        const fetchUserPosts = async () => {
+            try {
+                const result = await pb.collection("post").getList(1, 50, { // ✅ 1페이지, 50개 불러오기
+                    filter: `user = "${userId}"`,
+                    expand: "user",
+                });
+                setUserPosts(result.items);
+            } catch (err) {
+                console.error("게시물 가져오기 실패:", err);
+            }
+        };
+
+        if (userId) {
+            fetchUser();
+            fetchUserPosts();
+        }
     }, [userId]);
 
     const avatarUrl = profile?.avatar
@@ -27,33 +46,66 @@ const MyPage = () => {
 
     if (!profile) return <div>로딩 중...</div>;
 
-    return (
-        <div>
-            <h1>{profile.name}님의 마이페이지</h1>
-            <img src={avatarUrl} alt="프로필" className="w-32 h-32 rounded-full" />
+    const handlePostClick = (postId) => {
+        navigate(`/post/${postId}`);
+    };
 
-            {/* 로그인 유저와 비교 후 수정 기능 */}
+    return (
+        <div className="max-w-2xl mx-auto p-4">
+            <h1 className="text-2xl font-bold mb-4">{profile.name}님의 마이페이지</h1>
+            <img src={avatarUrl} alt="프로필" className="w-32 h-32 rounded-full mb-6" />
+
             {pb.authStore.model?.id === userId && (
                 <>
-                    <button onClick={() => setEditing(!editing)}>수정하기</button>
+                    <button onClick={() => setEditing(!editing)} className="bg-blue-500 text-white px-4 py-2 rounded mb-4">
+                        {editing ? "수정 취소" : "수정하기"}
+                    </button>
                     {editing && (
                         <form
                             onSubmit={async (e) => {
                                 e.preventDefault();
                                 const formData = new FormData();
-                                formData.append("nickname", nickname);
+                                formData.append("name", nickname); // ✅ 수정
                                 if (avatar) formData.append("avatar", avatar);
                                 await pb.collection("users").update(userId, formData);
                                 alert("수정 완료");
-                                location.reload(); // 또는 상태 갱신
+                                location.reload(); // 또는 fetchUser() 호출해서 다시 가져오기
                             }}
+                            className="flex flex-col gap-2"
                         >
-                            <input value={nickname} onChange={(e) => setNickname(e.target.value)} />
-                            <input type="file" onChange={(e) => setAvatar(e.target.files[0])} />
-                            <button type="submit">저장</button>
+                            <input
+                                className="border p-2 rounded"
+                                value={nickname}
+                                onChange={(e) => setNickname(e.target.value)}
+                            />
+                            <input
+                                type="file"
+                                onChange={(e) => setAvatar(e.target.files[0])}
+                            />
+                            <button type="submit" className="bg-green-500 text-white px-4 py-2 rounded">
+                                저장
+                            </button>
                         </form>
                     )}
                 </>
+            )}
+
+            <h2 className="text-xl font-semibold mt-8 mb-4">작성한 게시글</h2>
+            {userPosts.length > 0 ? (
+                <ul className="space-y-4">
+                    {userPosts.map((post) => (
+                        <li
+                            key={post.id}
+                            onClick={() => handlePostClick(post.id)}
+                            className="cursor-pointer border p-4 rounded hover:bg-gray-100"
+                        >
+                            <h3 className="font-bold text-lg">{post.title}</h3>
+                            <p className="text-gray-600">{post.description}</p>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p>작성한 게시글이 없습니다.</p>
             )}
         </div>
     );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,9 +1,38 @@
-import React from 'react'
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import pb from "../lib/pocketbase";
 
 const MyPage = () => {
-  return (
-    <div>MyPage</div>
-  )
-}
+    const { userId } = useParams();
+    const [profile, setProfile] = useState(null);
+    const [editing, setEditing] = useState(false);
+    const [avatar, setAvatar] = useState(null);
 
-export default MyPage
+    useEffect(() => {
+        const fetchUser = async () => {
+            try {
+                const data = await pb.collection("users").getOne(userId); // ✅ 이걸 기준으로 가져와야 함
+                setProfile(data);
+            } catch (err) {
+                console.error("유저 정보 불러오기 실패:", err);
+            }
+        };
+
+        if (userId) fetchUser();
+    }, [userId]);
+
+    const avatarUrl = profile?.avatar
+        ? pb.files.getURL(profile, profile.avatar)
+        : "https://via.placeholder.com/150";
+
+    if (!profile) return <div>로딩 중...</div>;
+
+    return (
+        <div>
+            <h1>{profile.name}님의 마이페이지</h1>
+            <img src={avatarUrl} alt="프로필" className="w-32 h-32 rounded-full" />
+        </div>
+    );
+};
+
+export default MyPage;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -43,6 +43,23 @@ const MyPage = () => {
         }
     }, [userId]);
 
+    useEffect(() => {
+        if (editing) {
+            // 수정모드 켜졌을 때
+            if (profile) {
+                setNickname(profile.name);
+                setIsNicknameAvailable(false); // 저장 불가능 상태로 초기화
+                setCheckingNickname(false);    // 중복확인 중 상태 초기화
+                setHasCheckedNickname(false); // 중복확인 여부 초기화
+            }
+        } else {
+            // 수정모드 꺼졌을 때
+            setNickname("");
+            setIsNicknameAvailable(false);
+            setCheckingNickname(false);
+        }
+    }, [editing, profile]);
+
     const avatarUrl = profile?.avatar
         ? pb.files.getURL(profile, profile.avatar)
         : "https://via.placeholder.com/150";

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -8,8 +8,11 @@ const MyPage = () => {
     const [profile, setProfile] = useState(null);
     const [editing, setEditing] = useState(false);
     const [avatar, setAvatar] = useState(null);
-    const [nickname, setNickname] = useState(""); // ✅ nickname 추가
+    const [nickname, setNickname] = useState("");
     const [userPosts, setUserPosts] = useState([]); // ✅ 내가 작성한 게시글 상태 추가
+    const [isNicknameAvailable, setIsNicknameAvailable] = useState(true);
+    const [hasCheckedNickname, setHasCheckedNickname] = useState(false); // ✅ 중복확인 버튼 누른 적 있는지
+    const [checkingNickname, setCheckingNickname] = useState(false); // ✅ 중복 체크 중 여부
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -50,6 +53,32 @@ const MyPage = () => {
         navigate(`/post/${postId}`);
     };
 
+    // 닉네임 중복 체크
+    const handleNicknameCheck = async () => {
+        if (nickname.trim() === "") {
+            alert("닉네임을 입력해주세요.");
+            return;
+        }
+    
+        setCheckingNickname(true);
+        setHasCheckedNickname(true); // ✅ 버튼 누르면 true로 변경
+        try {
+            const result = await pb.collection("users").getList(1, 1, {
+                filter: `name = "${nickname}" && id != "${userId}"`,
+            });
+            if (result.totalItems > 0) {
+                setIsNicknameAvailable(false);
+            } else {
+                setIsNicknameAvailable(true);
+            }
+        } catch (err) {
+            console.error("닉네임 중복 체크 실패:", err);
+            setIsNicknameAvailable(false);
+        } finally {
+            setCheckingNickname(false);
+        }
+    };
+    
     return (
         <div className="max-w-2xl mx-auto p-4">
             <h1 className="text-2xl font-bold mb-4">{profile.name}님의 마이페이지</h1>
@@ -73,16 +102,46 @@ const MyPage = () => {
                             }}
                             className="flex flex-col gap-2"
                         >
-                            <input
-                                className="border p-2 rounded"
-                                value={nickname}
-                                onChange={(e) => setNickname(e.target.value)}
-                            />
+                            <div className="flex gap-2 items-center">
+                                <div className="w-full">
+                                    <input
+                                        className="w-full border p-2 rounded flex-1"
+                                        value={nickname}
+                                        onChange={(e) => setNickname(e.target.value)}
+                                    />
+                                    {hasCheckedNickname && checkingNickname && (
+                                        <p className="text-blue-500 text-sm mt-1">닉네임 중복 확인 중...</p>
+                                    )}
+
+                                    {hasCheckedNickname && !checkingNickname && !isNicknameAvailable && (
+                                        <p className="text-red-500 text-sm mt-1">이미 사용 중인 닉네임입니다.</p>
+                                    )}
+
+                                    {hasCheckedNickname && !checkingNickname && isNicknameAvailable && nickname.trim() !== "" && (
+                                        <p className="text-green-500 text-sm mt-1">사용 가능한 닉네임입니다.</p>
+                                    )}
+
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={handleNicknameCheck} // ✅ 중복 확인 버튼
+                                    className="bg-blue-500 text-white px-4 py-2 rounded"
+                                >
+                                    중복 확인
+                                </button>
+                                
+                            </div>
                             <input
                                 type="file"
                                 onChange={(e) => setAvatar(e.target.files[0])}
                             />
-                            <button type="submit" className="bg-green-500 text-white px-4 py-2 rounded">
+                            <button
+                                type="submit"
+                                className={`px-4 py-2 rounded ${
+                                    isNicknameAvailable ? "bg-green-500 text-white" : "bg-gray-400 text-white cursor-not-allowed"
+                                }`}
+                                disabled={!isNicknameAvailable || nickname.trim() === ""}
+                            >
                                 저장
                             </button>
                         </form>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -31,6 +31,30 @@ const MyPage = () => {
         <div>
             <h1>{profile.name}님의 마이페이지</h1>
             <img src={avatarUrl} alt="프로필" className="w-32 h-32 rounded-full" />
+
+            {/* 로그인 유저와 비교 후 수정 기능 */}
+            {pb.authStore.model?.id === userId && (
+                <>
+                    <button onClick={() => setEditing(!editing)}>수정하기</button>
+                    {editing && (
+                        <form
+                            onSubmit={async (e) => {
+                                e.preventDefault();
+                                const formData = new FormData();
+                                formData.append("nickname", nickname);
+                                if (avatar) formData.append("avatar", avatar);
+                                await pb.collection("users").update(userId, formData);
+                                alert("수정 완료");
+                                location.reload(); // 또는 상태 갱신
+                            }}
+                        >
+                            <input value={nickname} onChange={(e) => setNickname(e.target.value)} />
+                            <input type="file" onChange={(e) => setAvatar(e.target.files[0])} />
+                            <button type="submit">저장</button>
+                        </form>
+                    )}
+                </>
+            )}
         </div>
     );
 };

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -29,10 +29,15 @@ const Post = () => {
         setIsLoading(true); // 🔹 데이터 요청 시작
         setIsDataLoaded(false); // 🔹 데이터 로드 상태 초기화
         try {
-            const posts = await pb.collection("post").getFullList({ autoCancel: false });
+            const posts = await pb.collection("post").getFullList({
+                autoCancel: false,
+                expand: "user", // ✅ 작성자 정보 포함
+            });
+    
             posts.forEach(post => {
                 post.updated = post.updated.split("T")[0];
             });
+    
             setPostData(posts.sort((a, b) => new Date(b.updated) - new Date(a.updated)));
             setIsDataLoaded(true); // 🔹 데이터 로드 완료
         } catch (error) {
@@ -41,7 +46,7 @@ const Post = () => {
             setIsLoading(false); // 🔹 데이터 요청 완료
         }
     };
-
+    
     return (
         <section className="flex flex-col items-center">
             <div className="flex justify-between w-full max-w-2xl">

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -23,7 +23,6 @@ const Post = () => {
     useEffect(() => {
         console.log("Post 컴포넌트가 리렌더링됨");
     });
-    
 
     const fetchPosts = async () => {
         setIsLoading(true); // 🔹 데이터 요청 시작
@@ -33,7 +32,7 @@ const Post = () => {
                 autoCancel: false,
                 expand: "user", // ✅ 작성자 정보 포함
             });
-    
+            
             posts.forEach(post => {
                 post.updated = post.updated.split("T")[0];
             });
@@ -89,14 +88,6 @@ const Post = () => {
                     fetchPosts={fetchPosts}  // ✅ 이미지 클릭 핸들러 전달
                 />
             )}
-
-            {/* ✅ PostImageModal을 selectedImage 상태에 따라 렌더링 */}
-            {/* {selectedImage && (
-                <PostImageModal 
-                    selectedImage={selectedImage} 
-                    setSelectedImage={setSelectedImage} 
-                />
-            )} */}
         </section>
     );
 };

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -1,53 +1,63 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
+import { Link } from "react-router-dom";
 
 const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+    const navigate = useNavigate();
 
     return (
         <div>
-            <div className="mb-2">
-                <p className="font-bold text-gray-700 mb-2">{post.editor}님</p>
-                <h2 className="text-xl font-bold">{post.title}</h2>
-                <p className="text-gray-700 mb-2">{post.description}</p>
-                <p className="text-sm text-gray-500">
-                    {new Date(post.updated).toISOString().split("T")[0]}
-                </p>
-            </div>
+            <Link to={`/mypage/${user.id}`} className="mb-2 pb-2 text-gray-500 flex font-bold border-b-2">
+                <b>
+                    {post.editor}님
+                </b>
+            </Link>
 
-            {/* 이미지 슬라이더 */}
-            {post.images && Array.isArray(post.images) ? (
-                <div onClick={onClick}>
-                    {isMobile ? (
-                        <Swiper navigation modules={[Navigation]}>
-                            {post.images.map((img, index) => (
-                                <SwiperSlide key={index}>
-                                    <img 
-                                        src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`} 
+            <div onClick={() => navigate(`/post/${post.id}`)}>
+                <div className="mb-2">
+                    {/* <p className="font-bold text-gray-700 mb-2">{post.editor}님</p> */}
+                    <h2 className="text-xl font-bold">{post.title}</h2>
+                    <p className="text-gray-700 mb-2">{post.description}</p>
+                    <p className="text-sm text-gray-500">
+                        {new Date(post.updated).toISOString().split("T")[0]}
+                    </p>
+                </div>
+                {/* 이미지 슬라이더 */}
+                {post.images && Array.isArray(post.images) ? (
+                    <div onClick={onClick}>
+                        {isMobile ? (
+                            <Swiper navigation modules={[Navigation]}>
+                                {post.images.map((img, index) => (
+                                    <SwiperSlide key={index}>
+                                        <img
+                                            src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`}
+                                            alt={post.title}
+                                            className="aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                            onClick={() => handleImageClick(img, post, true)}
+                                        />
+                                    </SwiperSlide>
+                                ))}
+                            </Swiper>
+                        ) : (
+                            <div className="flex space-x-2">
+                                {post.images.map((img, index) => (
+                                    <img
+                                        key={index}
+                                        src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`}
                                         alt={post.title}
-                                        className="aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
+                                        className="w-[32.5%] md:w-[32.8%] aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
                                         onClick={() => handleImageClick(img, post, true)}
                                     />
-                                </SwiperSlide>
-                            ))}
-                        </Swiper>
-                    ) : (
-                        <div className="flex space-x-2">
-                            {post.images.map((img, index) => (
-                                <img
-                                    key={index}
-                                    src={`${import.meta.env.VITE_PB_API}/files/${post.collectionId}/${post.id}/${img}`}
-                                    alt={post.title}
-                                    className="w-[32.5%] md:w-[32.8%] aspect-square object-cover rounded cursor-pointer hover:shadow-xl hover:opacity-80"
-                                    onClick={() => handleImageClick(img, post, true)}
-                                />
-                            ))}
-                        </div>
-                    )}
-                </div>
-            ) : null}
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                ) : null}
+            </div>
 
             <div className="flex justify-between items-center">
                 <div onClick={onClick}>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
@@ -6,20 +6,26 @@ import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
 import { Link } from "react-router-dom";
 
-const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
     const navigate = useNavigate();
+
+    useEffect(() => {
+        console.log("🧩 post:", post);
+        console.log("🧩 post.expand.user:", post.expand?.user);
+        console.log("🧩 post.expand.user.id:", post.expand?.user?.id);
+        console.log("🧩 post.expand.user.name:", post.expand?.user?.name);
+    }, [post]);
 
     return (
         <div>
-            <Link to={`/mypage/${user.id}`} className="mb-2 pb-2 text-gray-500 flex font-bold border-b-2">
-                <b>
-                    {post.editor}님
-                </b>
+            <Link to={`/mypage/${post.expand?.user?.id}`} 
+                className="mb-2 pb-2 text-gray-500 flex font-bold border-b-2 items-center">
+                <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
+                <b>{post.expand?.user?.name}님</b>
             </Link>
 
             <div onClick={() => navigate(`/post/${post.id}`)}>
                 <div className="mb-2">
-                    {/* <p className="font-bold text-gray-700 mb-2">{post.editor}님</p> */}
                     <h2 className="text-xl font-bold">{post.title}</h2>
                     <p className="text-gray-700 mb-2">{post.description}</p>
                     <p className="text-sm text-gray-500">
@@ -28,7 +34,7 @@ const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMo
                 </div>
                 {/* 이미지 슬라이더 */}
                 {post.images && Array.isArray(post.images) ? (
-                    <div onClick={onClick}>
+                    <div>
                         {isMobile ? (
                             <Swiper navigation modules={[Navigation]}>
                                 {post.images.map((img, index) => (
@@ -60,13 +66,13 @@ const PostContent = ({ commentCount, onClick, user, post, handleImageClick, isMo
             </div>
 
             <div className="flex justify-between items-center">
-                <div onClick={onClick}>
+                <div>
                     <p className="font-bold text-xs text-gray-500 mt-2">
                         댓글 ({commentCount}개)
                     </p>
                 </div>
                 {post && user && post.editor === user.name && (
-                    <div onClick={onClick}>
+                    <div>
                         <button
                             onClick={() => handleEdit(post)}
                             className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded"

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -33,7 +33,9 @@ const PostDetail = () => {
     // 해당하는 id의 게시물 가져오기
     const fetchPost = async () => {
         try {
-            const postData = await pb.collection("post").getOne(id);
+            const postData = await pb.collection("post").getOne(id, {
+                expand: "user", // ✅ 요거 추가!!!
+            });
             setPost(postData);
         } catch (error) {
             console.error("게시물 로드 실패:", error);
@@ -78,6 +80,10 @@ const PostDetail = () => {
 
     if (!post) return <p>게시물을 불러오는 중...</p>;
 
+    const avatarUrl = post?.expand?.user?.avatar
+    ? pb.files.getURL(post.expand.user, post.expand.user.avatar)
+    : "https://via.placeholder.com/150";
+
     return (
         <div className="max-w-2xl mx-auto p-4">
             <button onClick={() => navigate(-1)} className="text-blue-500 mb-4">← 뒤로가기</button>
@@ -92,6 +98,7 @@ const PostDetail = () => {
                     handleImageClick={handleImageClick}
                     commentCount={commentCount}
                     onCommentCountChange={setCommentCount}
+                    avatarUrl={avatarUrl}
                 />
             )}
 

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -19,7 +19,6 @@ const PostItem = ({
     setIsMobile 
 }) => {
     const { selectedImage, setSelectedImage, handleImageClick } = useImageViewer(); // 🔥 커스텀 훅 사용
-    const navigate = useNavigate();
     const [commentCount, setCommentCount] = useState(0); // ✅ 댓글 개수 상태
     
     useEffect(() => {
@@ -67,10 +66,13 @@ const PostItem = ({
         setEditModal(true); 
     };
 
+    const avatarUrl = post?.expand?.user?.avatar
+    ? pb.files.getURL(post.expand.user, post.expand.user.avatar)
+    : "https://via.placeholder.com/150";
+
     return (
         <li 
             className="border p-4 mb-2 rounded cursor-pointer hover:bg-slate-100"
-            // onClick={() => navigate(`/post/${post.id}`)} // ✅ `state`로 값 전달
         >
             <PostContent 
                 onClick={(e) => e.stopPropagation()} /* ✅ 부모 이벤트 방지 적용 */
@@ -81,6 +83,7 @@ const PostItem = ({
                 handleEdit={handleEdit}
                 handleImageClick={handleImageClick}
                 commentCount={commentCount}
+                avatarUrl={avatarUrl}
             />
 
             {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -70,7 +70,7 @@ const PostItem = ({
     return (
         <li 
             className="border p-4 mb-2 rounded cursor-pointer hover:bg-slate-100"
-            onClick={() => navigate(`/post/${post.id}`)} // ✅ `state`로 값 전달
+            // onClick={() => navigate(`/post/${post.id}`)} // ✅ `state`로 값 전달
         >
             <PostContent 
                 onClick={(e) => e.stopPropagation()} /* ✅ 부모 이벤트 방지 적용 */


### PR DESCRIPTION
branch : learn/MyPage

## ✨ 주요 변경사항

- `/mypage/:userId` 경로에 마이페이지(MyPage) 페이지 추가
- 로그인한 사용자의 헤더에 "마이페이지" 링크 추가
- 마이페이지에서 다음 기능 제공:
  - 사용자 프로필(닉네임, 아바타) 표시
  - 사용자 프로필 수정 (닉네임, 아바타 수정 가능)
  - 닉네임 중복 확인 버튼 추가
    - 중복확인 성공 시 저장 버튼 활성화
    - 실패 시 저장 불가
  - 수정 취소 시 입력값 및 상태 초기화
- 해당 사용자가 작성한 게시글 목록 표시
  - 게시글 클릭 시 게시글 상세 페이지로 이동
- 게시판(Post), 게시글 상세(PostDetail)에서도 작성자 정보(expand.user) 연결
- 전체적으로 코드 일관성 유지 및 구조 개선

## ✅ 주의사항
- 중복확인 버튼을 눌러야만 닉네임 사용 가능 여부가 확인됩니다.
- 저장 버튼은 닉네임 중복확인이 통과 되었을 때만 활성화됩니다.
- 
## ✅ 테스트 목록
- [x] 닉네임 수정이 정상적으로 가능하다
- [x] 프로필 수정이 정상적으로 가능하다
- [x] 닉네임 중복확인 버튼이 정상 동작한다
- [x] 내가 작성한 게시글 목록이 정상 출력된다
- [x] 게시글 클릭 시 상세 페이지로 이동된다

## 📂 관련 파일
- `src/pages/MyPage.jsx`
- `src/components/Header.jsx`
- `src/pages/Post.jsx`
- `src/pages/PostItem.jsx`
- `src/pages/PostContent.jsx`
- `src/pages/PostDetail.jsx`
- `src/App.jsx`