### PR TITLE
예약 기능 구현

### DIFF
--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -226,7 +226,7 @@ const MyPage = () => {
                         {/* ✅ 현재 로그인 유저가 이 페이지의 유저일 때만 취소 버튼 표시 */}
                         {isMyPage && user?.id === thisUser?.userId && (
                             <button
-                            onClick={async () => {
+                            onClick={async (e) => {
                                 e.stopPropagation(); // ⭐️ 리스트 클릭 방지
                                 const updated = reservations.filter(r => r.userId !== userId);
                                 await pb.collection("post").update(post.id, {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,9 +1,11 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import pb from "../lib/pocketbase";
+import { useUser } from "../context/UserContext";
 
 const MyPage = () => {
     const { userId } = useParams();
+    const user = useUser(); // 로그인한 사용자
     const navigate = useNavigate();
     const [profile, setProfile] = useState(null);
     const [editing, setEditing] = useState(false);
@@ -13,6 +15,8 @@ const MyPage = () => {
     const [isNicknameAvailable, setIsNicknameAvailable] = useState(true);
     const [hasCheckedNickname, setHasCheckedNickname] = useState(false); // ✅ 중복확인 버튼 누른 적 있는지
     const [checkingNickname, setCheckingNickname] = useState(false); // ✅ 중복 체크 중 여부
+    const [reservedPosts, setReservedPosts] = useState([]); // 예약관련 리스트
+    const isMyPage = user?.id === userId; // 로그인한 본인의 마이페이지인지 여부
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -59,6 +63,25 @@ const MyPage = () => {
             setCheckingNickname(false);
         }
     }, [editing, profile]);
+
+    const fetchReservedPosts = async () => {
+        const allPosts = await pb.collection("post").getFullList({ expand: "user" });
+      
+        const filtered = allPosts.filter(post => {
+          try {
+            const reservations = JSON.parse(post.reservations || "[]");
+            return reservations.some(r => r.userId === userId); // 마이페이지 주인 기준!
+          } catch {
+            return false;
+          }
+        });
+      
+        setReservedPosts(filtered);
+      };
+
+    useEffect(() => {
+        if (userId) fetchReservedPosts();
+    }, [userId]);
 
     const avatarUrl = profile?.avatar
         ? pb.files.getURL(profile, profile.avatar)
@@ -183,6 +206,44 @@ const MyPage = () => {
             ) : (
                 <p>작성한 게시글이 없습니다.</p>
             )}
+
+            <h2 className="text-xl font-semibold mt-8 mb-4">예약한 모임</h2>
+            {reservedPosts.length > 0 ? (
+            <ul className="space-y-4">
+                {reservedPosts.map((post) => {
+                const reservations = JSON.parse(post.reservations || "[]");
+                const thisUser = reservations.find(r => r.userId === userId);
+
+                return (
+                    <li key={post.id} className="border p-4 rounded">
+                        <h3 className="font-bold text-lg">{post.title}</h3>
+                        <p className="text-sm text-gray-600">{post.date} | {post.timeStart} ~ {post.timeEnd}</p>
+
+                        {/* ✅ 현재 로그인 유저가 이 페이지의 유저일 때만 취소 버튼 표시 */}
+                        {isMyPage && user?.id === thisUser?.userId && (
+                            <button
+                            onClick={async () => {
+                                const updated = reservations.filter(r => r.userId !== userId);
+                                await pb.collection("post").update(post.id, {
+                                reservations: JSON.stringify(updated)
+                                });
+                                alert("예약이 취소되었습니다.");
+                                fetchReservedPosts();
+                            }}
+                            className="mt-2 px-3 py-1 bg-red-500 text-white text-sm rounded"
+                            >
+                            예약 취소
+                            </button>
+                        )}
+                    </li>
+                );
+                })}
+            </ul>
+            ) : (
+            <p className="text-gray-500">예약한 모임이 없습니다.</p>
+            )}
+
+
         </div>
     );
 };

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -17,7 +17,7 @@ const MyPage = () => {
     const [checkingNickname, setCheckingNickname] = useState(false); // ✅ 중복 체크 중 여부
     const [reservedPosts, setReservedPosts] = useState([]); // 예약관련 리스트
     const isMyPage = user?.id === userId; // 로그인한 본인의 마이페이지인지 여부
-
+    
     useEffect(() => {
         const fetchUser = async () => {
             try {
@@ -215,7 +215,11 @@ const MyPage = () => {
                 const thisUser = reservations.find(r => r.userId === userId);
 
                 return (
-                    <li key={post.id} className="border p-4 rounded">
+                    <li 
+                        key={post.id} 
+                        className="border p-4 rounded"
+                        onClick={() => navigate(`/post/${post.id}`)}
+                    >
                         <h3 className="font-bold text-lg">{post.title}</h3>
                         <p className="text-sm text-gray-600">{post.date} | {post.timeStart} ~ {post.timeEnd}</p>
 
@@ -223,6 +227,7 @@ const MyPage = () => {
                         {isMyPage && user?.id === thisUser?.userId && (
                             <button
                             onClick={async () => {
+                                e.stopPropagation(); // ⭐️ 리스트 클릭 방지
                                 const updated = reservations.filter(r => r.userId !== userId);
                                 await pb.collection("post").update(post.id, {
                                 reservations: JSON.stringify(updated)

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -175,7 +175,6 @@ const PostContent = ({
                         className="w-6 h-6 rounded-full mr-1"
                         />
                         <span className="font-bold">{r.name}</span>
-                        <span className="ml-1">({r.count}명)</span>
                     </li>
                     ))}
                 </ul>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -21,6 +21,8 @@ const PostContent = ({
   }) => {
     const navigate = useNavigate();
     const [showReserveModal, setShowReserveModal] = useState(false);
+    const daysLeft = Math.ceil((new Date(post.date) - new Date()) / (1000 * 60 * 60 * 24));
+    const isClosingSoon = daysLeft > 0 && daysLeft <= 3;
 
     useEffect(() => {
         console.log("🧩 post:", post);
@@ -52,13 +54,20 @@ const PostContent = ({
                 <Link to={`/mypage/${post.expand?.user?.id}`}
                     className="text-gray-500 flex font-bold items-center">
                     <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
-                    <b>{post.expand?.user?.name}님</b>
+                    <b className="whitespace-nowrap">{post.expand?.user?.name}님</b>
                 </Link>
-                {isClosed ? (
-                    <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md">모집 마감</p>
-                    ) : (
-                    <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md">모집중</p>
-                )}
+                <div className="relative">
+                    {isClosed ? (
+                        <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md whitespace-nowrap">모집 마감</p>
+                        ) : (
+                        <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md whitespace-nowrap">모집중</p>
+                    )}
+                    {isClosingSoon && !isClosed && (
+                        <p className="absolute top-7 right-0 whitespace-nowrap text-xs px-2 py-1 text-white bg-orange-500 rounded-md">
+                            ⚠ 마감 {daysLeft}일 전
+                        </p>
+                    )}
+                </div>
             </div>
 
             <div onClick={() => navigate(`/post/${post.id}`)}>
@@ -131,8 +140,11 @@ const PostContent = ({
                 <p className="text-xs mr-2">{reservedCount} / {post.capacity}</p>
                 {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화 해야함 */}
                 {!isClosed && user?.id !== post.expand?.user?.id && (
-                    <button onClick={() => setShowReserveModal(true)} className="bg-blue-500 text-white px-2 py-1 rounded">
-                    예약하기
+                    <button 
+                        onClick={() => setShowReserveModal(true)} 
+                        className="bg-blue-500 text-white px-2 py-1 rounded text-xs"
+                    >
+                        예약하기
                     </button>
                 )}
 

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -18,6 +18,7 @@ const PostContent = ({
     handleDelete,
     handleEdit,
     fetchPosts,
+    showReservationsList,
   }) => {
     const navigate = useNavigate();
     const [showReserveModal, setShowReserveModal] = useState(false);
@@ -157,7 +158,7 @@ const PostContent = ({
                 )}
             </div>
 
-            {reservedUsers.length > 0 && (
+            {showReservationsList && reservedUsers.length > 0 && (
                 <div className="mt-4">
                 <b className="block mb-2">현재 예약한 인원들</b>
                 <ul className="flex flex-wrap gap-2">

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -1,13 +1,15 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
 import { Link } from "react-router-dom";
+import ReserveModal from "./ReserveModal";
 
-const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImageClick, isMobile, handleDelete, handleEdit }) => {
+const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, isMobile, handleDelete, handleEdit, fetchPosts }) => {
     const navigate = useNavigate();
+    const [showReserveModal, setShowReserveModal] = useState(false);
 
     useEffect(() => {
         console.log("🧩 post:", post);
@@ -24,10 +26,8 @@ const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImage
                     <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
                     <b>{post.expand?.user?.name}님</b>
                 </Link>
-                {/* 뱃지 - 모집중 */}
-                <p className="text-xs px-2 py-1 text-white bg-blue-500 w-fit h-fit rounded-md">모집중</p>
-                {/* 뱃지 - 모집마감 */}
-                <p className="text-xs px-2 py-1 text-white bg-gray-500 w-fit h-fit rounded-md">모집 마감</p>
+                <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md">모집 마감</p>
+                <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md">모집중</p>
             </div>
 
             <div onClick={() => navigate(`/post/${post.id}`)}>
@@ -98,23 +98,18 @@ const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImage
             {/* 예약관련 */}
             <div className="flex items-center justify-end">
                 <p className="text-xs mr-2">0/{post.capacity}</p>
-                {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화*/}
-                <button className="text-xs px-2 py-1 bg-emerald-600 text-white rounded">예약하기</button>
-            </div>
+                {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화 해야함 */}
+                <button onClick={() => setShowReserveModal(true)} className="bg-blue-500 text-white px-2 py-1 rounded">
+                    예약하기
+                </button>
 
-            {/* PostDetail페이지에서 열었을 경우 보임 */}
-            <div>
-                <b className="block mb-2">현재 예약한 인원들</b>
-                <ul className="flex flex-wrap gap-2">
-                    <li className="text-gray-500 flex items-center">
-                        <img src="해당 유저의 프로필" alt="프로필" className="w-6 h-6 rounded-full mr-1" />
-                        <b className="text-xs">신청한 user의 name1</b>
-                    </li>
-                    <li className="text-gray-500 flex items-center">
-                        <img src="해당 유저의 프로필" alt="프로필" className="w-6 h-6 rounded-full mr-1" />
-                        <b className="text-xs">신청한 user의 name2</b>
-                    </li>
-                </ul>
+                {showReserveModal && (
+                    <ReserveModal
+                        post={post}
+                        fetchPosts={fetchPosts}
+                        onClose={() => setShowReserveModal(false)}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -22,15 +22,6 @@ const PostContent = ({
   }) => {
     const navigate = useNavigate();
     const [showReserveModal, setShowReserveModal] = useState(false);
-    const daysLeft = Math.ceil((new Date(post.date) - new Date()) / (1000 * 60 * 60 * 24));
-    const isClosingSoon = daysLeft > 0 && daysLeft <= 3;
-
-    useEffect(() => {
-        console.log("🧩 post:", post);
-        console.log("🧩 post.expand.user:", post.expand?.user);
-        console.log("🧩 post.expand.user.id:", post.expand?.user?.id);
-        console.log("🧩 post.expand.user.name:", post.expand?.user?.name);
-    }, [post]);
 
     // 예약 정보 파싱
     const reservedUsers = (() => {
@@ -41,8 +32,22 @@ const PostContent = ({
         }
     })();
 
+    const daysLeft = Math.ceil((new Date(post.date) - new Date()) / (1000 * 60 * 60 * 24));
+    const isDateClosingSoon = daysLeft > 0 && daysLeft <= 3;
+    
     const reservedCount = reservedUsers.reduce((sum, r) => sum + r.count, 0);
     const isClosed = new Date(post.date) < new Date() || reservedCount >= Number(post.capacity);
+    const remainingSpots = Number(post.capacity) - reservedCount;
+    const isSpotsFew = remainingSpots <= Number(post.capacity) / 3;
+
+    const isClosingSoon = !isClosed && (isDateClosingSoon || isSpotsFew);
+
+    useEffect(() => {
+        console.log("🧩 post:", post);
+        console.log("🧩 post.expand.user:", post.expand?.user);
+        console.log("🧩 post.expand.user.id:", post.expand?.user?.id);
+        console.log("🧩 post.expand.user.name:", post.expand?.user?.name);
+    }, [post]);
     
     const getAvatarUrl = (userId, avatar) => {
         if (!avatar) return "https://via.placeholder.com/40";
@@ -57,16 +62,16 @@ const PostContent = ({
                     <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
                     <b className="whitespace-nowrap">{post.expand?.user?.name}님</b>
                 </Link>
-                <div className="relative">
+                <div className="flex items-center gap-1">
+                    {isClosingSoon && (
+                        <p className="top-7 right-0 whitespace-nowrap text-xs px-2 py-1 text-white bg-orange-500 rounded-md">
+                            마감 임박
+                        </p>
+                    )}
                     {isClosed ? (
                         <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md whitespace-nowrap">모집 마감</p>
                         ) : (
                         <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md whitespace-nowrap">모집중</p>
-                    )}
-                    {isClosingSoon && !isClosed && (
-                        <p className="absolute top-7 right-0 whitespace-nowrap text-xs px-2 py-1 text-white bg-orange-500 rounded-md">
-                            ⚠ 마감 {daysLeft}일 전
-                        </p>
                     )}
                 </div>
             </div>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -18,11 +18,17 @@ const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImage
 
     return (
         <div>
-            <Link to={`/mypage/${post.expand?.user?.id}`} 
-                className="mb-2 pb-2 text-gray-500 flex font-bold border-b-2 items-center">
-                <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
-                <b>{post.expand?.user?.name}님</b>
-            </Link>
+            <div className="border-b-2 flex items-center justify-between pb-2">
+                <Link to={`/mypage/${post.expand?.user?.id}`}
+                    className="text-gray-500 flex font-bold items-center">
+                    <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
+                    <b>{post.expand?.user?.name}님</b>
+                </Link>
+                {/* 뱃지 - 모집중 */}
+                <p className="text-xs px-2 py-1 text-white bg-blue-500 w-fit h-fit rounded-md">모집중</p>
+                {/* 뱃지 - 모집마감 */}
+                <p className="text-xs px-2 py-1 text-white bg-gray-500 w-fit h-fit rounded-md">모집 마감</p>
+            </div>
 
             <div onClick={() => navigate(`/post/${post.id}`)}>
                 <div className="mb-2">
@@ -65,7 +71,7 @@ const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImage
                 ) : null}
             </div>
 
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center mb-3">
                 <div>
                     <p className="font-bold text-xs text-gray-500 mt-2">
                         댓글 ({commentCount}개)
@@ -75,18 +81,40 @@ const PostContent = ({ avatarUrl, commentCount, onClick, user, post, handleImage
                     <div>
                         <button
                             onClick={() => handleEdit(post)}
-                            className="mt-2 px-2 py-1 bg-yellow-500 text-white rounded"
+                            className="text-xs px-2 py-1 mt-2 bg-yellow-500 text-white rounded"
                         >
                             수정
                         </button>
                         <button
                             onClick={() => handleDelete(post)}
-                            className="ml-2 px-2 py-1 bg-red-500 text-white rounded"
+                            className="text-xs px-2 py-1 ml-2 bg-red-500 text-white rounded"
                         >
                             삭제
                         </button>
                     </div>
                 )}
+            </div>
+
+            {/* 예약관련 */}
+            <div className="flex items-center justify-end">
+                <p className="text-xs mr-2">0/{post.capacity}</p>
+                {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화*/}
+                <button className="text-xs px-2 py-1 bg-emerald-600 text-white rounded">예약하기</button>
+            </div>
+
+            {/* PostDetail페이지에서 열었을 경우 보임 */}
+            <div>
+                <b className="block mb-2">현재 예약한 인원들</b>
+                <ul className="flex flex-wrap gap-2">
+                    <li className="text-gray-500 flex items-center">
+                        <img src="해당 유저의 프로필" alt="프로필" className="w-6 h-6 rounded-full mr-1" />
+                        <b className="text-xs">신청한 user의 name1</b>
+                    </li>
+                    <li className="text-gray-500 flex items-center">
+                        <img src="해당 유저의 프로필" alt="프로필" className="w-6 h-6 rounded-full mr-1" />
+                        <b className="text-xs">신청한 user의 name2</b>
+                    </li>
+                </ul>
             </div>
         </div>
     );

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -112,7 +112,7 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
 
             {/* 예약관련 */}
             <div className="flex items-center justify-end">
-                <p className="text-xs mr-2">0/{post.capacity}</p>
+                <p className="text-xs mr-2">{reservedCount} / {post.capacity}</p>
                 {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화 해야함 */}
                 <button onClick={() => setShowReserveModal(true)} className="bg-blue-500 text-white px-2 py-1 rounded">
                     예약하기
@@ -136,7 +136,6 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
                     {reservedUsers.map((r, i) => (
                     <li key={i} className="text-gray-500 flex items-center text-xs">
                         <span className="font-bold">{r.name}</span>
-                        <span className="ml-1">({r.count}명)</span>
                     </li>
                     ))}
                 </ul>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -114,9 +114,11 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
             <div className="flex items-center justify-end">
                 <p className="text-xs mr-2">{reservedCount} / {post.capacity}</p>
                 {/* 다른 유저가 쓴 게시물 일경우 예약하기 버튼 활성화 해야함 */}
-                <button onClick={() => setShowReserveModal(true)} className="bg-blue-500 text-white px-2 py-1 rounded">
+                {!isClosed && user?.id !== post.expand?.user?.id && (
+                    <button onClick={() => setShowReserveModal(true)} className="bg-blue-500 text-white px-2 py-1 rounded">
                     예약하기
-                </button>
+                    </button>
+                )}
 
                 {showReserveModal && (
                     <ReserveModal

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -6,8 +6,19 @@ import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
 import { Link } from "react-router-dom";
 import ReserveModal from "./ReserveModal";
+import pb from "../lib/pocketbase";
 
-const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, isMobile, handleDelete, handleEdit, fetchPosts }) => {
+const PostContent = ({
+    avatarUrl,
+    commentCount,
+    user,
+    post,
+    handleImageClick,
+    isMobile,
+    handleDelete,
+    handleEdit,
+    fetchPosts,
+  }) => {
     const navigate = useNavigate();
     const [showReserveModal, setShowReserveModal] = useState(false);
 
@@ -29,6 +40,11 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
 
     const reservedCount = reservedUsers.reduce((sum, r) => sum + r.count, 0);
     const isClosed = new Date(post.date) < new Date() || reservedCount >= Number(post.capacity);
+    
+    const getAvatarUrl = (userId, avatar) => {
+        if (!avatar) return "https://via.placeholder.com/40";
+        return `${pb.baseUrl}/api/files/users/${userId}/${avatar}`;
+    };
 
     return (
         <div>
@@ -129,15 +145,19 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
                 )}
             </div>
 
-            {/* PostDetail페이지에서 열었을 경우 보여야 함 */}
-            {/* 예약한 유저 목록 */}
             {reservedUsers.length > 0 && (
                 <div className="mt-4">
                 <b className="block mb-2">현재 예약한 인원들</b>
                 <ul className="flex flex-wrap gap-2">
                     {reservedUsers.map((r, i) => (
                     <li key={i} className="text-gray-500 flex items-center text-xs">
+                        <img
+                        src={getAvatarUrl(r.userId, r.avatar)}
+                        alt={r.name}
+                        className="w-6 h-6 rounded-full mr-1"
+                        />
                         <span className="font-bold">{r.name}</span>
+                        <span className="ml-1">({r.count}명)</span>
                     </li>
                     ))}
                 </ul>

--- a/src/pages/PostContent.jsx
+++ b/src/pages/PostContent.jsx
@@ -18,6 +18,18 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
         console.log("🧩 post.expand.user.name:", post.expand?.user?.name);
     }, [post]);
 
+    // 예약 정보 파싱
+    const reservedUsers = (() => {
+        try {
+        return post.reservations ? JSON.parse(post.reservations) : [];
+        } catch {
+        return [];
+        }
+    })();
+
+    const reservedCount = reservedUsers.reduce((sum, r) => sum + r.count, 0);
+    const isClosed = new Date(post.date) < new Date() || reservedCount >= Number(post.capacity);
+
     return (
         <div>
             <div className="border-b-2 flex items-center justify-between pb-2">
@@ -26,8 +38,11 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
                     <img src={avatarUrl} alt="프로필" className="w-8 h-8 rounded-full mr-1" />
                     <b>{post.expand?.user?.name}님</b>
                 </Link>
-                <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md">모집 마감</p>
-                <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md">모집중</p>
+                {isClosed ? (
+                    <p className="text-xs px-2 py-1 text-white bg-gray-500 rounded-md">모집 마감</p>
+                    ) : (
+                    <p className="text-xs px-2 py-1 text-white bg-blue-500 rounded-md">모집중</p>
+                )}
             </div>
 
             <div onClick={() => navigate(`/post/${post.id}`)}>
@@ -111,6 +126,22 @@ const PostContent = ({ avatarUrl, commentCount, user, post, handleImageClick, is
                     />
                 )}
             </div>
+
+            {/* PostDetail페이지에서 열었을 경우 보여야 함 */}
+            {/* 예약한 유저 목록 */}
+            {reservedUsers.length > 0 && (
+                <div className="mt-4">
+                <b className="block mb-2">현재 예약한 인원들</b>
+                <ul className="flex flex-wrap gap-2">
+                    {reservedUsers.map((r, i) => (
+                    <li key={i} className="text-gray-500 flex items-center text-xs">
+                        <span className="font-bold">{r.name}</span>
+                        <span className="ml-1">({r.count}명)</span>
+                    </li>
+                    ))}
+                </ul>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -99,6 +99,7 @@ const PostDetail = () => {
                     commentCount={commentCount}
                     onCommentCountChange={setCommentCount}
                     avatarUrl={avatarUrl}
+                    showReservationsList={true} // ✅ 예약자 목록 표시
                 />
             )}
 

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -100,6 +100,7 @@ const PostDetail = () => {
                     onCommentCountChange={setCommentCount}
                     avatarUrl={avatarUrl}
                     showReservationsList={true} // ✅ 예약자 목록 표시
+                    fetchPosts={fetchPosts}
                 />
             )}
 

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -84,6 +84,7 @@ const PostItem = ({
                 handleImageClick={handleImageClick}
                 commentCount={commentCount}
                 avatarUrl={avatarUrl}
+                fetchPosts={fetchPosts}
             />
 
             {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}

--- a/src/pages/PostItem.jsx
+++ b/src/pages/PostItem.jsx
@@ -85,6 +85,7 @@ const PostItem = ({
                 commentCount={commentCount}
                 avatarUrl={avatarUrl}
                 fetchPosts={fetchPosts}
+                showReservationsList={false} // ❌ 예약자 목록 숨김
             />
 
             {/* ✅ PostImageModal 추가하여 클릭한 이미지 확대 가능 */}

--- a/src/pages/ReserveModal.jsx
+++ b/src/pages/ReserveModal.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const ReserveModal = () => {
+    
+  return (
+    <div>ReserveModal</div>
+  )
+}
+
+export default ReserveModal

--- a/src/pages/ReserveModal.jsx
+++ b/src/pages/ReserveModal.jsx
@@ -25,9 +25,10 @@ const ReserveModal = ({ post, onClose, fetchPosts }) => {
     }
 
     const newReservations = [...existing, {
-      name: user.name,
-      userId: user.id,
-      count: 1,
+        name: user.name,
+        userId: user.id,
+        count: 1,
+        avatar: user.avatar || "",
     }];
 
     setLoading(true);

--- a/src/pages/ReserveModal.jsx
+++ b/src/pages/ReserveModal.jsx
@@ -1,10 +1,81 @@
-import React from 'react'
+import React, { useState } from "react";
+import pb from "../lib/pocketbase";
+import { useUser } from "../context/UserContext";
 
-const ReserveModal = () => {
-    
+const ReserveModal = ({ post, onClose, fetchPost }) => {
+  const user = useUser();
+  const [loading, setLoading] = useState(false);
+
+  const handleReserve = async () => {
+    if (!user) return alert("로그인이 필요합니다");
+
+    let existing = [];
+    try {
+      existing = post.reservations ? JSON.parse(post.reservations) : [];
+    } catch {
+      existing = [];
+    }
+
+    const alreadyReserved = existing.find((r) => r.userId === user.id);
+    if (alreadyReserved) return alert("이미 예약한 모임입니다");
+
+    const reservedCount = existing.reduce((sum, r) => sum + r.count, 0);
+    if (reservedCount + 1 > Number(post.capacity)) {
+      return alert("모집 인원을 초과했습니다");
+    }
+
+    const newReservations = [...existing, {
+      name: user.name,
+      userId: user.id,
+      count: 1,
+    }];
+
+    setLoading(true);
+    try {
+      await pb.collection("post").update(post.id, {
+        reservations: JSON.stringify(newReservations),
+      });
+      alert("예약 완료!");
+      if (fetchPost) fetchPost();
+      onClose();
+    } catch (err) {
+      console.error("예약 실패:", err);
+      alert("예약에 실패했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>ReserveModal</div>
-  )
-}
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-6 w-80">
+        <h2 className="text-xl font-bold mb-4">모임 예약</h2>
 
-export default ReserveModal
+        {/* post 정보 출력 */}
+        <div className="text-sm text-gray-700 mb-4 space-y-1">
+          <p><b>날짜:</b> {post.date}</p>
+          <p><b>시간:</b> {post.timeStart} ~ {post.timeEnd}</p>
+          <p><b>장소:</b> {post.location}</p>
+          <p><b>정원:</b> {post.capacity}명</p>
+          <p><b>참가비:</b> {post.fee}원</p>
+        </div>
+
+        <button
+          onClick={handleReserve}
+          disabled={loading}
+          className="w-full bg-green-500 text-white py-2 rounded mb-2"
+        >
+          {loading ? "예약 중..." : "예약하기"}
+        </button>
+        <button
+          onClick={onClose}
+          className="w-full bg-gray-400 text-white py-2 rounded"
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReserveModal;

--- a/src/pages/ReserveModal.jsx
+++ b/src/pages/ReserveModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import pb from "../lib/pocketbase";
 import { useUser } from "../context/UserContext";
 
-const ReserveModal = ({ post, onClose, fetchPost }) => {
+const ReserveModal = ({ post, onClose, fetchPosts }) => {
   const user = useUser();
   const [loading, setLoading] = useState(false);
 
@@ -32,17 +32,17 @@ const ReserveModal = ({ post, onClose, fetchPost }) => {
 
     setLoading(true);
     try {
-      await pb.collection("post").update(post.id, {
-        reservations: JSON.stringify(newReservations),
-      });
-      alert("예약 완료!");
-      if (fetchPost) fetchPost();
-      onClose();
+        await pb.collection("post").update(post.id, {
+            reservations: JSON.stringify(newReservations),
+        });
+        alert("예약 완료!");
+        if (fetchPosts) fetchPosts();
+        onClose();
     } catch (err) {
-      console.error("예약 실패:", err);
-      alert("예약에 실패했습니다");
+        console.error("예약 실패:", err);
+        alert("예약에 실패했습니다");
     } finally {
-      setLoading(false);
+        setLoading(false);
     }
   };
 

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -58,37 +58,57 @@ const StepPostPage = ({ post }) => {
     // 포켓베이스
     const handleSubmitPost = async () => {
         try {
-            const form = new FormData();
-            form.append("title", formData.title);
-            form.append("description", formData.description);
-            form.append("location", formData.location);
-            form.append("date", formData.date);
-            form.append("timeStart", formData.timeStart);
-            form.append("timeEnd", formData.timeEnd);
-            form.append("capacity", formData.capacity);
-            form.append("fee", formData.fee);
-            form.append("user", user.id); // 현재 로그인 유저 ID
-            form.append("editor", user.name); // ✅ editor 추가
-    
-            // category 배열은 문자열로 변환 (예: "중식,일식")
-            form.append("category", formData.category.join(","));
-    
-            // 이미지 파일 업로드
-            postImgs.forEach((file) => {
-                if (file instanceof File) {
-                    form.append("images", file);
-                }
-            });
-    
-            await pb.collection("post").create(form);
-            localStorage.removeItem(STORAGE_KEY);
-            alert("게시물이 등록되었습니다!");
-            navigate("/post");
+          const form = new FormData();
+      
+          // 필수 텍스트 필드
+          form.append("title", formData.title.trim());
+          form.append("description", formData.description.trim());
+          form.append("location", formData.location.trim());
+          form.append("date", formData.date);
+          form.append("timeStart", formData.timeStart);
+          form.append("timeEnd", formData.timeEnd);
+      
+          // 숫자 필드 → 문자열로 변환
+          form.append("capacity", String(Number(formData.capacity)));
+          form.append("fee", String(Number(formData.fee)));
+      
+          // 유저 정보
+          if (!user || !user.id || !user.name) {
+            alert("로그인이 필요합니다.");
+            return;
+          }
+          form.append("user", user.id);
+          form.append("editor", user.name);
+      
+          // 카테고리 문자열
+          const categoryStr = formData.category.join(",");
+          if (!categoryStr) {
+            alert("카테고리를 선택해주세요.");
+            return;
+          }
+          form.append("category", categoryStr);
+      
+          // 이미지 1개 이상 필수
+          const validFiles = postImgs.filter(file => file instanceof File);
+          if (validFiles.length === 0) {
+            alert("이미지를 1개 이상 업로드해주세요.");
+            return;
+          }
+      
+          validFiles.forEach((file) => {
+            form.append("images", file);
+          });
+      
+          await pb.collection("post").create(form);
+          localStorage.removeItem(STORAGE_KEY);
+          alert("게시물이 등록되었습니다!");
+          navigate("/post");
         } catch (err) {
-            console.error("게시물 등록 실패", err);
-            alert("게시물 등록에 실패했습니다. 다시 시도해주세요.");
+          console.error("게시물 등록 실패", err);
+          alert("게시물 등록에 실패했습니다. 다시 시도해주세요.");
         }
     };
+      
 
     const handleManualSave = () => {
         const serializedImages = postImgs.map(file => file.name);

--- a/src/pages/StepPostPage.jsx
+++ b/src/pages/StepPostPage.jsx
@@ -156,24 +156,19 @@ const StepPostPage = ({ post }) => {
         });
     };
 
-    const uploadFiles = async (e) => {
+      const uploadFiles = async (e) => {
         const files = Array.from(e.target.files);
       
-        if ((post?.field?.length || 0) + postImgs.length + files.length > 3) {
+        if ((post?.images?.length || 0) + postImgs.length + files.length > 3) {
           alert("업로드 이미지 개수를 초과하였습니다. (최대 3개)");
           return;
         }
       
-        try {
-          const compressedFiles = await compressImages(files); // ⬅️ 이미지 압축 훅 사용
-      
-          const newPreviewImgs = compressedFiles.map(file => URL.createObjectURL(file));
-          setPostImgs(prev => [...prev, ...compressedFiles].slice(0, 3));
-          setPreviewImgs(prev => [...prev, ...newPreviewImgs].slice(0, 3));
-        } catch (err) {
-          alert("이미지 압축 중 문제가 발생했습니다.");
-        }
+        const newPreviewImgs = files.map((file) => URL.createObjectURL(file));
+        setPostImgs((prev) => [...prev, ...files].slice(0, 3));
+        setPreviewImgs((prev) => [...prev, ...newPreviewImgs].slice(0, 3));
       };
+      
 
     const removePreviewImage = (index) => {
         setPreviewImgs(prev => prev.filter((_, i) => i !== index));


### PR DESCRIPTION
branch : learn/Reserve

## ✨ 예약 기능 구현: 예약, 취소, 마감 상태 및 마이페이지 연동

### 📌 주요 변경 사항

1. **Post 예약 기능 구현**
   - `post.reservations` 필드에 JSON 문자열로 사용자 예약 정보 저장
   - 예약 시 로그인 사용자 정보(`name`, `userId`, `avatar`, `count`) 포함
   - 예약 인원은 1명 고정

2. **PostContent: 예약 상태 표시**
   - 예약 인원 수 및 정원 표시 (`n / capacity`)
   - 모집 마감 판단: 날짜 경과 or 정원 초과
   - 마감 임박 뱃지 추가:  
     - D-Day 3일 이하  
     - 남은 인원 1/3 이하

3. **ReserveModal 모달 구현**
   - 예약 정보 확인 UI (`date`, `time`, `location`, `capacity`, `fee`)
   - 예약 완료 시 `fetchPost` 후 `window.location.reload()`로 최신화
   - 예약 중복 및 정원 초과 방지

4. **예약자 목록 표시 (`PostDetail`에서만)**
   - 예약자 이름 + 아바타 렌더링
   - `showReservationsList` prop으로 분기

5. **예약 취소 기능**
   - 본인이 예약한 경우에만 "예약 취소" 버튼 노출
   - 취소 시 `post.reservations`에서 사용자 정보 제거 및 DB 갱신

6. **마이페이지에 내가 예약한 모임 리스트 추가**
   - `/mypage/:userId` → 해당 유저가 예약한 모임 목록 표시
   - 리스트 클릭 시 상세 페이지로 이동
   - 본인 마이페이지인 경우에만 `예약 취소 버튼` 표시

---

### ✅ 기타 개선 사항
- PostContent 리팩토링: 예약 상태 관련 로직 분리
- e.stopPropagation()으로 `예약 취소 버튼 클릭 시 게시물 이동 방지`

---

### 🎯 앞으로 개선 가능 포인트
- 모집 마감 게시물 처리